### PR TITLE
Helpers: Make StopAllPopupWatchers really remove a watcher

### DIFF
--- a/AutomationHelpers/src/UserCodeCollections/PopupWatcherLibrary.cs
+++ b/AutomationHelpers/src/UserCodeCollections/PopupWatcherLibrary.cs
@@ -18,6 +18,15 @@ namespace Ranorex.AutomationHelpers.UserCodeCollections
         private static readonly Dictionary<string, PopupWatcher> watchers = new Dictionary<string, PopupWatcher>();
 
         /// <summary>
+        /// Gets the currently active watchers which were started using the <see cref="StartPopupWatcher"/>
+        /// method and have not been stopped using the <see cref="StopPopupWatcher"/> method, yet.
+        /// </summary>
+        /// <value>
+        /// The currently active watchers created using the <see cref="PopupWatcherLibrary"/> class.
+        /// </value>
+        public static IList<PopupWatcher> Watchers { get { return new List<PopupWatcher>(watchers.Values); } }
+
+        /// <summary>
         /// Waits for a popup window to appear and clicks an element to close the window.
         /// </summary>
         /// <param name="findElement">Element to wait for</param>
@@ -53,10 +62,7 @@ namespace Ranorex.AutomationHelpers.UserCodeCollections
             PopupWatcher watcher = null;
             if (watchers.TryGetValue(key, out watcher))
             {
-                watcher.Clear();
-                watcher.Stop();
-                Report.Info("Popup watcher stopped.");
-                watchers.Remove(key);
+                StopPopupWatcher(key, watcher);
             }
             else
             {
@@ -70,12 +76,18 @@ namespace Ranorex.AutomationHelpers.UserCodeCollections
         [UserCodeMethod]
         public static void StopAllPopupWatchers()
         {
-            foreach (var watcher in watchers.Values)
+            foreach (var watcher in watchers)
             {
-                watcher.Clear();
-                watcher.Stop();
-                Report.Info("Popup watcher stopped.");
+                StopPopupWatcher(watcher.Key, watcher.Value);
             }
+        }
+
+        private static void StopPopupWatcher(string key, PopupWatcher watcher)
+        {
+            watcher.Clear();
+            watcher.Stop();
+            Report.Info("Popup watcher stopped.");
+            watchers.Remove(key);
         }
     }
 }

--- a/AutomationHelpers/test/PopupWatcherLibraryTests.cs
+++ b/AutomationHelpers/test/PopupWatcherLibraryTests.cs
@@ -113,5 +113,28 @@ namespace RanorexAutomationHelpers.Test
             Report.DetachLogger(logger);
             Assert.AreEqual("Popup watcher stopped.", logger.LastLogMessage);
         }
+
+        [Test]
+        public void StopAllPopupWatcherTest_RemovesAllEntries_Success()
+        {
+            //Arrange
+            var parentFolder = Substitute.For<RepoGenBaseFolder>("Form1", "/form", null, Duration.Zero, true);
+            var repoItemInfo1 = new RepoItemInfo(parentFolder, "self", RxPath.Parse(string.Empty), Duration.Zero, null, Guid.NewGuid().ToString());
+            var repoItemInfo2 = new RepoItemInfo(parentFolder, "self", RxPath.Parse(string.Empty), Duration.Zero, null, Guid.NewGuid().ToString());
+            var logger = new TestReportLogger();
+            logger.LogTextCount = 0;
+            Report.AttachLogger(logger);
+            PopupWatcherLibrary.StartPopupWatcher(repoItemInfo1, repoItemInfo1);
+            PopupWatcherLibrary.StartPopupWatcher(repoItemInfo2, repoItemInfo2);
+
+            //Act
+            PopupWatcherLibrary.StopAllPopupWatchers();
+
+            //Assert
+            Report.DetachLogger(logger);
+            Assert.AreEqual(2, logger.LogTextCount);
+            Assert.AreEqual("Popup watcher stopped.", logger.LastLogMessage);
+            Assert.AreEqual(0, PopupWatcherLibrary.Watchers.Count);
+        }
     }
 }

--- a/AutomationHelpers/test/TestReportLogger.cs
+++ b/AutomationHelpers/test/TestReportLogger.cs
@@ -14,6 +14,8 @@ namespace RanorexAutomationHelpers.Test
 
         internal string LastLogMessage { get; set; }
 
+        internal int LogTextCount { get; set; }
+
         public void End()
         {
             // Method intentionally left empty.
@@ -27,6 +29,7 @@ namespace RanorexAutomationHelpers.Test
         public void LogText(ReportLevel level, string category, string message, bool escape, IDictionary<string, string> metaInfos)
         {
             this.LastLogMessage = message;
+            this.LogTextCount++;
         }
 
         public void Start()


### PR DESCRIPTION
By internally calling StopPopupWatcher on each registered watcher.

Fixes issue #22