### PR TITLE
Helpers: Add scripts to automatically set version as compile symbol

### DIFF
--- a/AutomationHelpers/Ranorex.AutomationHelpers.nuspec
+++ b/AutomationHelpers/Ranorex.AutomationHelpers.nuspec
@@ -26,5 +26,7 @@
     </metadata>
     <files>
         <file src="src\**\*.cs" target="content" />
+        <file src="scripts\install.ps1" target="tools\install.ps1" />
+        <file src="scripts\uninstall.ps1" target="tools\uninstall.ps1" />
     </files>
 </package>

--- a/AutomationHelpers/scripts/install.ps1
+++ b/AutomationHelpers/scripts/install.ps1
@@ -1,0 +1,27 @@
+# Copyright © 2018 Ranorex All rights reserved
+
+param($installPath, $toolsPath, $package, $project)
+
+Write-Host 'Started adding constant for current Ranorex version to compilation symbols...'
+
+$rxVersion = $project.Properties.Item("RanorexVersion")
+$rxVersion = $rxVersion.Value -replace '\.'
+if (!$rxVersion)
+{
+    Write-Warning('Could not find Ranorex version property in project.')
+    exit
+}
+$rxVersion = "RX$rxVersion"
+
+$defineConstants = $project.Properties.Item("DefineConstants")
+[array]$symbols = $defineConstants.Value.Split(';')
+Write-Host "Found: $symbols"
+$symbols = $symbols | Where {$_[0] -ne 'R' -and $_[1] -ne 'X'}
+
+$symbols += $rxVersion
+
+$symbolString = $symbols -join ';'
+Write-Host "Replace with: $symbolString"
+$defineConstants.Value = $symbolString
+
+Write-Host 'Finished adding Ranorex version to compilation symbols.'

--- a/AutomationHelpers/scripts/uninstall.ps1
+++ b/AutomationHelpers/scripts/uninstall.ps1
@@ -1,0 +1,24 @@
+# Copyright © 2018 Ranorex All rights reserved
+
+param($installPath, $toolsPath, $package, $project)
+
+Write-Host 'Started removing constant for current Ranorex version from compilation symbols...'
+
+$rxVersion = $project.Properties.Item("RanorexVersion")
+$rxVersion = $rxVersion.Value -replace '\.'
+if (!$rxVersion)
+{
+    Write-Information('Could not find Ranorex version property, ignore removing constant for this project.')
+    exit
+}
+
+$defineConstants = $project.Properties.Item("DefineConstants")
+[array]$symbols = $defineConstants.Value.Split(';')
+Write-Host "Found: $symbols"
+$symbols = $symbols | Where {$_[0] -ne 'R' -and $_[1] -ne 'X'}
+
+$symbolString = $symbols -join ';'
+Write-Host "Replace with: $symbolString"
+$defineConstants.Value = $symbolString
+
+Write-Host 'Finished removing Ranorex specific compilation symbols.'

--- a/AutomationHelpers/src/Modules/CleanupRanorexReport.cs
+++ b/AutomationHelpers/src/Modules/CleanupRanorexReport.cs
@@ -1,0 +1,85 @@
+﻿//
+// Copyright © 2018 Ranorex All rights reserved
+//
+
+using System;
+using System.IO;
+using Ranorex.Core.Reporting;
+
+namespace Ranorex.AutomationHelpers.Modules
+{
+    internal sealed class CleanupRanorexReport
+    {
+        private readonly System.DateTime testSuiteCompleted;
+
+        internal CleanupRanorexReport(System.DateTime testSuiteCompleted)
+        {
+            this.testSuiteCompleted = testSuiteCompleted;
+        }
+
+        /// <summary>
+        /// Used to cleanup and delete all Ranorex report related files from current testrun
+        /// </summary>
+        internal void Cleanup()
+        {
+            try
+            {
+                var reportFileDirectory = TestReport.ReportEnvironment.ReportFileDirectory;
+                var name = TestReport.ReportEnvironment.ReportName;
+
+                var reportDataFile = TestReport.ReportEnvironment.ReportDataFilePath;
+                var reportFile = string.Format(@"{0}\{1}.{2}", reportFileDirectory, name, GetReportExtension());
+
+                DeleteReportImages();
+
+                File.Delete(reportDataFile);
+                File.Delete(reportFile);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException("Failed to delete Ranorex report files: " + ex.Message);
+            }
+        }
+
+        private void DeleteReportImages()
+        {
+            //Check if images are stored within a subdirectory - default
+            if (TestReport.ReportEnvironment.UseScreenshotFolder)
+            {
+                var imageFolderDirectoryInfo = new DirectoryInfo(TestReport.ReportEnvironment.ReportScreenshotFolderPath);
+
+                if(imageFolderDirectoryInfo.Exists)
+                {
+                    imageFolderDirectoryInfo.Delete(true);
+                }
+            }
+
+            //Delete image files, which match the report short name and aren't older then currently created report
+            else
+            {
+                const int MaxPrefixLen = 8;
+                var shortName = TestReport.ReportEnvironment.ReportName.Substring(0, Math.Min(TestReport.ReportEnvironment.ReportName.Length, MaxPrefixLen));
+                var imageFolderDirectoryInfo = new DirectoryInfo(TestReport.ReportEnvironment.ReportScreenshotFolderPath);
+
+                if(imageFolderDirectoryInfo.Exists)
+                {
+                    foreach (var image in imageFolderDirectoryInfo.GetFiles(string.Format("*{0}*.jpg", shortName)))
+                    {
+                        var imageCreationTime = File.GetCreationTime(image.FullName);
+
+                        if (testSuiteCompleted < imageCreationTime.AddSeconds(10)) //Added 10 secs to the imageCreationTime to ensure the images are actually created
+                        {
+                            image.Delete();
+                        }
+                    }
+                }
+            }
+        }
+
+        private string GetReportExtension()
+        {
+            var extension = TestReport.ReportEnvironment.ReportDataFilePath.Split('.');
+            return extension[extension.Length - 2];
+        }
+    }
+}


### PR DESCRIPTION
...so that we can ensure compatibility by excluding new code for older
runtimes using compile symbols, e.g. RX81 for 8.1.x
Sets the constant for currently enabled configuration only, for others
it still has to be set manually...