### PR TITLE
Helpers: Remove Ranorex report

### DIFF
--- a/AutomationHelpers/src/Modules/CleanupRanorexReport.cs
+++ b/AutomationHelpers/src/Modules/CleanupRanorexReport.cs
@@ -78,17 +78,8 @@ namespace Ranorex.AutomationHelpers.Modules
 
         private string GetReportExtension()
         {
-            var reportDataFile = TestReport.ReportEnvironment.ReportDataFilePath;
-            var extension = reportDataFile.Substring(reportDataFile.Length - 10).Split('.');
-
-            if (extension.Length == 3)
-            {
-                return "html";
-            }
-            else
-            {
-                return "rxlog";
-            }
+            var extension = TestReport.ReportEnvironment.ReportDataFilePath.Split('.');
+            return extension[extension.Length - 2];
         }
     }
 }

--- a/AutomationHelpers/src/Modules/CleanupRanorexReport.cs
+++ b/AutomationHelpers/src/Modules/CleanupRanorexReport.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using Ranorex.Core;
+using System;
+using Ranorex.Core.Reporting;
+using System.IO;
+
+namespace Ranorex.AutomationHelpers.Modules
+{
+    class CleanupRanorexReport
+    {
+        private System.DateTime testSuiteCompleted;
+
+        public CleanupRanorexReport(System.DateTime testSuiteCompleted)
+        {
+            this.testSuiteCompleted = testSuiteCompleted;
+        }
+
+        /// <summary>
+        /// Used to cleanup and delete all Ranorex report related files from current testrun
+        /// </summary>
+        internal void Cleanup()
+        {
+            try
+            {
+                var reportFileDirectory = TestReport.ReportEnvironment.ReportFileDirectory;
+                var name = TestReport.ReportEnvironment.ReportName;
+
+                var reportDataFile = TestReport.ReportEnvironment.ReportDataFilePath;
+                var reportFile = String.Format(@"{0}\{1}.{2}", reportFileDirectory, name, GetReportExtension());
+
+                DeleteReportImages();
+
+                File.Delete(reportDataFile);
+                File.Delete(reportFile);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Failed to delete Ranorex report files: " + ex.Message);
+            }
+        }
+
+        private void DeleteReportImages()
+        {
+            //Check if images are stored within a subdirectory - default
+            if (TestReport.ReportEnvironment.UseScreenshotFolder)
+            {
+                var imageFolderDirectoryInfo = new DirectoryInfo(TestReport.ReportEnvironment.ReportScreenshotFolderPath);
+
+                if(imageFolderDirectoryInfo.Exists)
+                {
+                    imageFolderDirectoryInfo.Delete(true);
+                }
+            }
+
+            //Delete image files, which match the report short name and aren't older then currently created report
+            else
+            {
+                const int MaxPrefixLen = 8;
+                var shortName = TestReport.ReportEnvironment.ReportName.Substring(0, Math.Min(TestReport.ReportEnvironment.ReportName.Length, MaxPrefixLen));
+                var imageFolderDirectoryInfo = new DirectoryInfo(TestReport.ReportEnvironment.ReportScreenshotFolderPath);
+
+                if(imageFolderDirectoryInfo.Exists)
+                {
+                    foreach (var image in imageFolderDirectoryInfo.GetFiles(String.Format("*{0}*.jpg", shortName)))
+                    {
+                        var imageCreationTime = File.GetCreationTime(image.FullName);
+
+                        if (testSuiteCompleted < imageCreationTime.AddSeconds(10)) //Added 10 secs to the imageCreationTime to ensure the images are actually created
+                        {
+                            image.Delete();
+                        }
+                    }
+                }
+            }
+        }
+
+        private string GetReportExtension()
+        {
+            var reportDataFile = TestReport.ReportEnvironment.ReportDataFilePath;
+            var extension = reportDataFile.Substring(reportDataFile.Length - 10).Split('.');
+
+            if (extension.Length == 3)
+            {
+                return "html";
+            }
+
+            else
+            {
+                return "rxlog";
+            }
+        }
+    }
+}

--- a/AutomationHelpers/src/Modules/CleanupRanorexReport.cs
+++ b/AutomationHelpers/src/Modules/CleanupRanorexReport.cs
@@ -1,16 +1,18 @@
-﻿using System.Collections.Generic;
-using Ranorex.Core;
+﻿//
+// Copyright © 2018 Ranorex All rights reserved
+//
+
 using System;
-using Ranorex.Core.Reporting;
 using System.IO;
+using Ranorex.Core.Reporting;
 
 namespace Ranorex.AutomationHelpers.Modules
 {
-    class CleanupRanorexReport
+    internal sealed class CleanupRanorexReport
     {
-        private System.DateTime testSuiteCompleted;
+        private readonly System.DateTime testSuiteCompleted;
 
-        public CleanupRanorexReport(System.DateTime testSuiteCompleted)
+        internal CleanupRanorexReport(System.DateTime testSuiteCompleted)
         {
             this.testSuiteCompleted = testSuiteCompleted;
         }
@@ -26,7 +28,7 @@ namespace Ranorex.AutomationHelpers.Modules
                 var name = TestReport.ReportEnvironment.ReportName;
 
                 var reportDataFile = TestReport.ReportEnvironment.ReportDataFilePath;
-                var reportFile = String.Format(@"{0}\{1}.{2}", reportFileDirectory, name, GetReportExtension());
+                var reportFile = string.Format(@"{0}\{1}.{2}", reportFileDirectory, name, GetReportExtension());
 
                 DeleteReportImages();
 
@@ -35,7 +37,7 @@ namespace Ranorex.AutomationHelpers.Modules
             }
             catch (Exception ex)
             {
-                throw new Exception("Failed to delete Ranorex report files: " + ex.Message);
+                throw new InvalidOperationException("Failed to delete Ranorex report files: " + ex.Message);
             }
         }
 
@@ -61,7 +63,7 @@ namespace Ranorex.AutomationHelpers.Modules
 
                 if(imageFolderDirectoryInfo.Exists)
                 {
-                    foreach (var image in imageFolderDirectoryInfo.GetFiles(String.Format("*{0}*.jpg", shortName)))
+                    foreach (var image in imageFolderDirectoryInfo.GetFiles(string.Format("*{0}*.jpg", shortName)))
                     {
                         var imageCreationTime = File.GetCreationTime(image.FullName);
 
@@ -83,7 +85,6 @@ namespace Ranorex.AutomationHelpers.Modules
             {
                 return "html";
             }
-
             else
             {
                 return "rxlog";

--- a/AutomationHelpers/src/Modules/ReportToPDFModule.cs
+++ b/AutomationHelpers/src/Modules/ReportToPDFModule.cs
@@ -44,9 +44,11 @@ namespace Ranorex.AutomationHelpers.Modules
 
         [TestVariable("b9993b89-d8cb-45fe-829b-42b0f8dd8a00")]
         public string Details { get; set; }
-		
+
+#if !RX72 && !RX80 //this requires Ranorex 8.1+ -> make sure 'RX81' is set in conditional compilation symbols in project properties
         [TestVariable("7f788c18-962c-41ab-b591-9c3122512c5e")]
         public string DeleteRanorexReport { get; set; }
+#endif
 
         /// <summary>
         /// Converts the Ranorex Report into PDF after the test run completed. Use this module in
@@ -69,7 +71,8 @@ namespace Ranorex.AutomationHelpers.Modules
                     CreatePDF();
                 };
 
-				TestSuiteRunner.TestRunCompleted += delegate
+#if !RX72 && !RX80 //this requires Ranorex 8.1+ -> make sure 'RX81' is set in conditional compilation symbols in project properties
+                TestSuiteRunner.TestRunCompleted += delegate
                 {
                     if (GetCastedDeleteRanorexReport(DeleteRanorexReport))
                     {
@@ -77,6 +80,7 @@ namespace Ranorex.AutomationHelpers.Modules
                         cleaner.Cleanup();
                     }
                 };
+#endif
 
                 this.registered = true;
             }
@@ -227,7 +231,7 @@ namespace Ranorex.AutomationHelpers.Modules
 
             return status;
         }
-		
+
         /// <summary>
         /// Returns a boolean interpretation from the "DeleteRanorexReport" variable
         /// </summary>


### PR DESCRIPTION
• Cleanup Ranorex Report after test execution
• Fixed “FileExists()” check, which prevented from overriding existing PDF reports