### PR TITLE
Helpers: Add argument null check to StartPopupWatcher

### DIFF
--- a/AutomationHelpers/src/UserCodeCollections/PopupWatcherLibrary.cs
+++ b/AutomationHelpers/src/UserCodeCollections/PopupWatcherLibrary.cs
@@ -39,6 +39,9 @@ namespace Ranorex.AutomationHelpers.UserCodeCollections
         [UserCodeMethod]
         public static PopupWatcher StartPopupWatcher(RepoItemInfo findElement, RepoItemInfo clickElement)
         {
+            CheckArgumentNotNull(findElement, "findElement");
+            CheckArgumentNotNull(clickElement, "clickElement");
+
             var key = findElement.GetMetaInfos()["id"] + clickElement.GetMetaInfos()["id"];
 
             if (watchers.ContainsKey(key))
@@ -62,10 +65,7 @@ namespace Ranorex.AutomationHelpers.UserCodeCollections
         [UserCodeMethod]
         public static PopupWatcher PauseWhileExists(RepoItemInfo findElement)
         {
-            if (findElement == null)
-            {
-                throw new ArgumentNullException("findElement");
-            }
+            CheckArgumentNotNull(findElement, "findElement");
 
             var key = findElement.GetMetaInfos()["id"];
 
@@ -90,6 +90,9 @@ namespace Ranorex.AutomationHelpers.UserCodeCollections
         [UserCodeMethod]
         public static void StopPopupWatcher(RepoItemInfo findElement, RepoItemInfo clickElement)
         {
+            CheckArgumentNotNull(findElement, "findElement");
+            CheckArgumentNotNull(clickElement, "clickElement");
+
             var key = findElement.GetMetaInfos()["id"] + clickElement.GetMetaInfos()["id"];
             PopupWatcher watcher = null;
             if (watchers.TryGetValue(key, out watcher))
@@ -134,6 +137,14 @@ namespace Ranorex.AutomationHelpers.UserCodeCollections
             watcher.Stop();
             Report.Info("Popup watcher stopped.");
             watchers.Remove(key);
+        }
+
+        private static void CheckArgumentNotNull(object argument, string argumentName)
+        {
+            if (argument == null)
+            {
+                throw new ArgumentNullException(argumentName);
+            }
         }
     }
 }

--- a/AutomationHelpers/test/PopupWatcherLibraryTests.cs
+++ b/AutomationHelpers/test/PopupWatcherLibraryTests.cs
@@ -15,20 +15,32 @@ namespace RanorexAutomationHelpers.Test
     [TestFixture]
     public sealed class PopupWatcherLibraryTests
     {
+        private TestReportLogger logger;
+
+        [SetUp]
+        public void Init()
+        {
+            logger = new TestReportLogger();
+            Report.AttachLogger(logger);
+        }
+
+        [TearDown]
+        public void Dispose()
+        {
+            Report.DetachLogger(logger);
+        }
+
         [Test]
         public void StartPopupWatcherTest_Single_Success()
         {
             //Arrange
             var parentFolder = Substitute.For<RepoGenBaseFolder>("Form1", "/notExistent", null, Duration.Zero, true);
             var repoItemInfo = new RepoItemInfo(parentFolder, "self", RxPath.Parse(string.Empty), Duration.Zero, null);
-            var logger = new TestReportLogger();
-            Report.AttachLogger(logger);
 
             //Act
             var watcher = PopupWatcherLibrary.StartPopupWatcher(repoItemInfo, repoItemInfo);
 
             //Assert
-            Report.DetachLogger(logger);
             Assert.IsNotNull(watcher);
             Assert.AreEqual("Popup watcher started.", logger.LastLogMessage);
         }
@@ -39,8 +51,6 @@ namespace RanorexAutomationHelpers.Test
             //Arrange
             var parentFolder = Substitute.For<RepoGenBaseFolder>("Form1", "/notExistent", null, Duration.Zero, true);
             var repoItemInfo = new RepoItemInfo(parentFolder, "self", RxPath.Parse(string.Empty), Duration.Zero, null, Guid.NewGuid().ToString());
-            var logger = new TestReportLogger();
-            Report.AttachLogger(logger);
 
             //Act
             try
@@ -52,9 +62,15 @@ namespace RanorexAutomationHelpers.Test
             }
             catch (ArgumentException ex)
             {
-                Report.DetachLogger(logger);
                 Assert.AreEqual("Popup watcher with given parameters already exists.", ex.Message);
             }
+        }
+
+        [Test]
+        public void StartPopupWatcherTest_WithoutParameters_ThrowsException()
+        {
+            //Assert
+            Assert.Throws<ArgumentNullException>(() => PopupWatcherLibrary.StartPopupWatcher(null, null));
         }
 
         [Test]
@@ -63,15 +79,12 @@ namespace RanorexAutomationHelpers.Test
             //Arrange
             var parentFolder = Substitute.For<RepoGenBaseFolder>("Form1", "/notExistent", null, Duration.Zero, true);
             var repoItemInfo = new RepoItemInfo(parentFolder, "self", RxPath.Parse(string.Empty), Duration.Zero, null, Guid.NewGuid().ToString());
-            var logger = new TestReportLogger();
-            Report.AttachLogger(logger);
             var watcher = PopupWatcherLibrary.StartPopupWatcher(repoItemInfo, repoItemInfo);
 
             //Act
             PopupWatcherLibrary.StopPopupWatcher(repoItemInfo, repoItemInfo);
 
             //Assert
-            Report.DetachLogger(logger);
             Assert.IsNotNull(watcher);
             Assert.AreEqual("Popup watcher stopped.", logger.LastLogMessage);
         }
@@ -82,14 +95,11 @@ namespace RanorexAutomationHelpers.Test
             //Arrange
             var parentFolder = Substitute.For<RepoGenBaseFolder>("Form1", "/notExistent", null, Duration.Zero, true);
             var repoItemInfo = new RepoItemInfo(parentFolder, "self", RxPath.Parse(string.Empty), Duration.Zero, null, Guid.NewGuid().ToString());
-            var logger = new TestReportLogger();
-            Report.AttachLogger(logger);
 
             //Act
             PopupWatcherLibrary.StopPopupWatcher(repoItemInfo, repoItemInfo);
 
             //Assert
-            Report.DetachLogger(logger);
             Assert.AreEqual("The popup watcher you tried to remove does not exist.", logger.LastLogMessage);
         }
 
@@ -100,8 +110,6 @@ namespace RanorexAutomationHelpers.Test
             var parentFolder = Substitute.For<RepoGenBaseFolder>("Form1", "/notExistent", null, Duration.Zero, true);
             var repoItemInfo1 = new RepoItemInfo(parentFolder, "self", RxPath.Parse(string.Empty), Duration.Zero, null, Guid.NewGuid().ToString());
             var repoItemInfo2 = new RepoItemInfo(parentFolder, "self", RxPath.Parse(string.Empty), Duration.Zero, null, Guid.NewGuid().ToString());
-            var logger = new TestReportLogger();
-            Report.AttachLogger(logger);
             PopupWatcherLibrary.StartPopupWatcher(repoItemInfo1, repoItemInfo1);
             PopupWatcherLibrary.StartPopupWatcher(repoItemInfo2, repoItemInfo2);
 
@@ -110,7 +118,6 @@ namespace RanorexAutomationHelpers.Test
             PopupWatcherLibrary.StopPopupWatcher(repoItemInfo2, repoItemInfo2);
 
             //Assert
-            Report.DetachLogger(logger);
             Assert.AreEqual("Popup watcher stopped.", logger.LastLogMessage);
         }
 
@@ -121,8 +128,6 @@ namespace RanorexAutomationHelpers.Test
             var parentFolder = Substitute.For<RepoGenBaseFolder>("Form1", "/notExistent", null, Duration.Zero, true);
             var repoItemInfo1 = new RepoItemInfo(parentFolder, "self", RxPath.Parse(string.Empty), Duration.Zero, null, Guid.NewGuid().ToString());
             var repoItemInfo2 = new RepoItemInfo(parentFolder, "self", RxPath.Parse(string.Empty), Duration.Zero, null, Guid.NewGuid().ToString());
-            var logger = new TestReportLogger();
-            Report.AttachLogger(logger);
             PopupWatcherLibrary.StartPopupWatcher(repoItemInfo1, repoItemInfo1);
             PopupWatcherLibrary.StartPopupWatcher(repoItemInfo2, repoItemInfo2);
 
@@ -130,7 +135,6 @@ namespace RanorexAutomationHelpers.Test
             PopupWatcherLibrary.StopAllPopupWatchers();
 
             //Assert
-            Report.DetachLogger(logger);
             Assert.AreEqual("Popup watcher stopped.", logger.LastLogMessage);
             Assert.AreEqual(0, PopupWatcherLibrary.Watchers.Count);
         }

--- a/AutomationHelpers/test/PopupWatcherLibraryTests.cs
+++ b/AutomationHelpers/test/PopupWatcherLibraryTests.cs
@@ -69,7 +69,6 @@ namespace RanorexAutomationHelpers.Test
         [Test]
         public void StartPopupWatcherTest_WithoutParameters_ThrowsException()
         {
-            //Assert
             //Arrange
             var parentFolder = Substitute.For<RepoGenBaseFolder>("Form1", "/notExistent", null, Duration.Zero, true);
             var repoItemInfo = new RepoItemInfo(parentFolder, "self", RxPath.Parse(string.Empty), Duration.Zero, null);

--- a/AutomationHelpers/test/PopupWatcherLibraryTests.cs
+++ b/AutomationHelpers/test/PopupWatcherLibraryTests.cs
@@ -70,7 +70,13 @@ namespace RanorexAutomationHelpers.Test
         public void StartPopupWatcherTest_WithoutParameters_ThrowsException()
         {
             //Assert
-            Assert.Throws<ArgumentNullException>(() => PopupWatcherLibrary.StartPopupWatcher(null, null));
+            //Arrange
+            var parentFolder = Substitute.For<RepoGenBaseFolder>("Form1", "/notExistent", null, Duration.Zero, true);
+            var repoItemInfo = new RepoItemInfo(parentFolder, "self", RxPath.Parse(string.Empty), Duration.Zero, null);
+            
+            //Act + Assert
+            Assert.Throws<ArgumentNullException>(() => PopupWatcherLibrary.StartPopupWatcher(repoItemInfo, null));
+            Assert.Throws<ArgumentNullException>(() => PopupWatcherLibrary.StartPopupWatcher(null, repoItemInfo));
         }
 
         [Test]


### PR DESCRIPTION
StartPopupWatcher originally throws generic null exception, added validation of parameters that are not null. Null check from other function refactored to reduce code duplication.

Also added a test to cover the case where null arguments are passed, and refactored some common actions from test methods into Setup and TearDown.