### PR TITLE
Helpers: Fix PDF and folder validation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "Eyes/ImageTester"]
-	path = Eyes/ImageTester
-	url = https://github.com/Didddy/ImageTester
-	branch = topic/CSharp

--- a/Eyes/ImageTester/README.md
+++ b/Eyes/ImageTester/README.md
@@ -1,0 +1,104 @@
+# Image Tester [ ![Download](https://api.bintray.com/packages/applitoolseyes/generic/ImageTester/images/download.svg) ](https://bintray.com/applitoolseyes/generic/download_file?file_path=ImageTester.jar)
+ImageTester is a Cli tool to perform visual tests on images or PDF files. 
+
+If you don't have your Applitools account yet, 
+please [sign up first]("https://applitools.com/sign-up/") 
+and get your Applitools api-key that will be used next to execute the tests.
+
+The tool can be invoked on a single file or a complex folder structure with mixed content.
+Once provided a complex folder structure the tool recursively scans the structure and determines on each level what should be the batch-name, 
+the test-name and the tag values relatively to the target files.  
+For example, given the following folder structure:
+```
++- Folder A  
+|  +- Folder B
+|  |  +- Screenshot1.png
+|  |  +- Screenshot2.png
+|  +- Folder C
+|  |  +- Screenshot3.png
+|  |  +- Screenshot4.png
+|  |  +- Screenshot5.png
+```
+The following tests will be generated in Applitools:
+```
+Batch name - A:
+    Test name - B > steps: Screenshot1, Screenshot2
+    Test name - C > steps: Screenshot3, Screenshot4, Screenshot5
+```
+
+The parameters for Applitools test will be derived from the file and the folder structure according to the following table:
+
+|            | Single image file                           | Multi-image file (PDF)            | 
+|------------|---------------------------------------------|-----------------------------------|
+| Step tag   | The filename                                | Step index                        |
+| Test name  | Parent folder-name if applicable*           | The filename                      |
+| Batch name | 2nd level parent folfer-name if applicable* | Parent folder-name if applicable* |
+
+\* When no sufficient levels in the specified structure to derive all test parameters, the values will be taken from the child value.
+For example, for the following structure:
+```
++- Folder A
+|  +- Screenshot1.png
+|  +- Screenshot2.png
+
+```
+The following test will be generated in Applitools:
+```
+Batch name - A:
+    Test name - A > steps: Screenshot1, Screenshot2
+```
+Note that the batch name was derived from the test name as there is no additional 
+folder level that can be used as batch name.
+
+## Execution
+The tool build in java and requires minimal set of parametersm the minimal command will look as follow:
+
+>java -jar ImageTester.jar -k [api-key]
+
+\* In the minimal set of parameters will assume that the search folder is the execution folder.
+
++ Required parameters:
+    + `-k [api-key]` - Applitools api key
++ Optional paramaeters:
+    + `-f [path]` - A path to target folder or file
+    + `-a [app-name]` - Set custom application name; default = ImageTester
+    + `-p [http://proxy{;user;pass}]` - Set proxy and optional username + password
+    + `-s [server]` - Set Applitools server url
+    + `-ml [match-level]` - Set the comparison level, one from Strict/Content/Layout; Default = Strict
+    + `-br [branch]` - Set the branch
+    + `-pb [parent-branch]` - Set the parent branch
+    + `-bn [baseline]` - Set custom baseline name
+    + `-vs [WidthxHeight]` - Set the viewport size identifier
+    + `-lf [log-file]` - Set log fine name to enable logging
+    + `-as` - Set automatic save on failures
+    + `-os [osname]` - Set custom os
+    + `-ap [app name]` - Set browser or equivalent application name  
+    ######For PDFs only
+    + `-di [dpi]` - Set the quality of the conversion on PDF files
+    + `-sp [pages]` - Comma separated page numbers to include in PDF testing (ie: 1,2,5,7); Default all included
+    + `-pp [password]` - The password if the PDF files protected
+ 
+## Enterprise features in combination with [Eyes Utilities](https://github.com/yanirta/EyesUtilities)
+By placing the Eyes-Utilities jar into the same folder as the ImageTester, new enterprise api features
+made possible by providing an enterprise read-key.
+
+>java -jar ImageTester.jar -k [api-key] -vk [view-key] [options]
++ Required parameters:
+    + `-k [api-key]` - Applitools api key
+    + `-vk [view-key]` - Applitools enterprise view-key
++ Selective flags - Required one or more
+    + `-gd` - Get diff images of the failed steps
+    + `-gi` - Get images of the failed steps
+    + `-gd` - Get animated gifs of the failed steps
+
+# Supporting regions
+To validate only a specific regions of a particular image the folder must contain .regions file with the same name as the image.
+ie. If my image file is 'step1.png' then the regions file should be 'step1.regions'.
+Internally the format should be 4 columns csv in the following order: left,top,width,height
+
+Here is an example of what can be step1.regions:
+```
+0,0,100,200
+500,100,240,123
+```
+In order to include a capture of the entire image too, add an empty line as part of the regions list.

--- a/Eyes/ImageTester/pom.xml
+++ b/Eyes/ImageTester/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.applitools</groupId>
+    <artifactId>ImageTester</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <repositories>
+        <repository>
+            <id>org.ghost4j.repository.releases</id>
+            <name>Ghost4J releases</name>
+            <url>http://repo.ghost4j.org/maven2/releases</url>
+        </repository>
+        <repository>
+            <id>org.ghost4j.repository.snapshots</id>
+            <name>Ghost4J snapshots</name>
+            <url>http://repo.ghost4j.org/maven2/snapshots</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>com.applitools</groupId>
+            <artifactId>eyes-images-java3</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.ghost4j</groupId>
+            <artifactId>ghost4j</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/Eyes/ImageTester/src/csharp/ImageTester.sln
+++ b/Eyes/ImageTester/src/csharp/ImageTester.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2036
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Applitools.ImageTester.Runner", "main\Applitools.ImageTester.Runner.csproj", "{B21498AD-E651-4738-9A72-1156D0F7871D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Applitools.ImageTester", "lib\Applitools.ImageTester.csproj", "{CD3852A3-83F4-42D2-A109-9D3DA663691A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B21498AD-E651-4738-9A72-1156D0F7871D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B21498AD-E651-4738-9A72-1156D0F7871D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B21498AD-E651-4738-9A72-1156D0F7871D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B21498AD-E651-4738-9A72-1156D0F7871D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD3852A3-83F4-42D2-A109-9D3DA663691A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD3852A3-83F4-42D2-A109-9D3DA663691A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD3852A3-83F4-42D2-A109-9D3DA663691A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD3852A3-83F4-42D2-A109-9D3DA663691A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EEF02256-F1E7-41FE-B6BE-E8BF05C613ED}
+	EndGlobalSection
+EndGlobal

--- a/Eyes/ImageTester/src/csharp/lib/Applitools.ImageTester.csproj
+++ b/Eyes/ImageTester/src/csharp/lib/Applitools.ImageTester.csproj
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\PdfiumViewer.Native.x86_64.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86_64.v8-xfa.props" Condition="Exists('..\packages\PdfiumViewer.Native.x86_64.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86_64.v8-xfa.props')" />
+  <Import Project="..\packages\PdfiumViewer.Native.x86.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86.v8-xfa.props" Condition="Exists('..\packages\PdfiumViewer.Native.x86.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86.v8-xfa.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CD3852A3-83F4-42D2-A109-9D3DA663691A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Applitools.ImageTester</RootNamespace>
+    <AssemblyName>Applitools.ImageTester</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Eyes.Bundle, Version=1.22.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\bin\Release\Eyes.Bundle.dll</HintPath>
+    </Reference>
+    <Reference Include="PdfiumViewer, Version=2.12.0.0, Culture=neutral, PublicKeyToken=91e4789cfb0609e0, processorArchitecture=MSIL">
+      <HintPath>..\packages\PdfiumViewer.2.12.0.0\lib\net20\PdfiumViewer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Interfaces\ITestable.cs" />
+    <Compile Include="SuiteBuilder.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestObjects\Batch.cs" />
+    <Compile Include="TestObjects\ImageStep.cs" />
+    <Compile Include="TestObjects\PDFTest.cs" />
+    <Compile Include="TestObjects\Suite.cs" />
+    <Compile Include="TestObjects\Test.cs" />
+    <Compile Include="TestObjects\TestUnit.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="x64\pdfium.dll" />
+    <Content Include="x86\pdfium.dll" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets" Condition="Exists('..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets'))" />
+    <Error Condition="!Exists('..\packages\PdfiumViewer.Native.x86.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86.v8-xfa.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PdfiumViewer.Native.x86.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86.v8-xfa.props'))" />
+    <Error Condition="!Exists('..\packages\PdfiumViewer.Native.x86_64.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86_64.v8-xfa.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PdfiumViewer.Native.x86_64.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86_64.v8-xfa.props'))" />
+  </Target>
+  <!-- ILRepack -->
+  <Target Name="BeforeBuild">
+    <ItemGroup>
+      <InputAssemblies Include="..\packages\Eyes.Images.1.22.0\lib\net35\Eyes.Images.dll" />
+      <InputAssemblies Include="..\packages\Eyes.Sdk.2.5.3\lib\net45\Eyes.Sdk.DotNet.dll" />
+      <InputAssemblies Include="..\packages\Eyes.Sdk.2.5.3\lib\net45\Eyes.Utils.DotNet.dll" />
+      <InputAssemblies Include="..\packages\DotNetZip.Reduced.1.9.1.8\lib\net20\Ionic.Zip.Reduced.dll" />
+      <InputAssemblies Include="..\packages\log4net.2.0.0\lib\net40-full\log4net.dll" />
+      <InputAssemblies Include="..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll" />
+    </ItemGroup>
+    <ILRepack InputAssemblies="@(InputAssemblies)" TargetKind="Dll" OutputFile="$(OutputPath)\Eyes.Bundle.dll" />
+  </Target>
+  <!-- /ILRepack -->
+</Project>

--- a/Eyes/ImageTester/src/csharp/lib/Interfaces/ITestable.cs
+++ b/Eyes/ImageTester/src/csharp/lib/Interfaces/ITestable.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Applitools.Images;
+
+namespace Applitools.ImageTester.Interfaces
+{
+    public interface ITestable : IDisposable
+    {
+        void Run(Eyes eyes);
+        string Name();
+    }
+}

--- a/Eyes/ImageTester/src/csharp/lib/Properties/AssemblyInfo.cs
+++ b/Eyes/ImageTester/src/csharp/lib/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Lib")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Lib")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("cd3852a3-83f4-42d2-a109-9d3da663691a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Eyes/ImageTester/src/csharp/lib/SuiteBuilder.cs
+++ b/Eyes/ImageTester/src/csharp/lib/SuiteBuilder.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using Applitools.ImageTester.Interfaces;
+using Applitools.ImageTester.TestObjects;
+
+namespace Applitools.ImageTester
+{
+    public class SuiteBuilder
+    {
+        private readonly string rootFolder;
+        private readonly string appname;
+        private readonly Size viewport;
+        private float pdfdpi_ = 300F;
+        private string pdfPassword_;
+        private string pages_;
+
+        public virtual string GetPages()
+        {
+            return pages_;
+        }
+
+        public virtual void SetPages(string steps)
+        {
+            this.pages_ = steps;
+        }
+
+        public SuiteBuilder(string rootFolder, string appname, Size viewport)
+        {
+            this.rootFolder = rootFolder;
+            this.appname = appname;
+            this.viewport = viewport;
+        }
+
+        public virtual ITestable Build()
+        {
+            return Build(rootFolder, appname, viewport);
+        }
+
+        public virtual void SetDpi(float dpi)
+        {
+            this.pdfdpi_ = dpi;
+        }
+
+        private ITestable Build(string curr, string appname, Size viewport)
+        {
+            string jenkinsJobName = Environment.GetEnvironmentVariable("JOB_NAME");
+            string jenkinsApplitoolsBatchId = Environment.GetEnvironmentVariable("APPLITOOLS_BATCH_ID");
+            Batch jenkinsBatch = null;
+            if ((jenkinsJobName != null) && (jenkinsApplitoolsBatchId != null))
+            {
+                BatchInfo batch = new BatchInfo(jenkinsJobName);
+                batch.Id = jenkinsApplitoolsBatchId;
+                jenkinsBatch = new Batch(batch);
+            }
+
+            ITestable unit = Build(curr, appname, viewport, jenkinsBatch);
+            if (unit is ImageStep)
+            {
+                ImageStep step = (ImageStep)unit;
+                Test test = new Test(step.GetFile(), appname, this.viewport);
+                test.AddStep(step);
+                unit = test;
+            }
+
+            if (unit is Test && jenkinsBatch != null)
+            {
+                jenkinsBatch.AddTest((Test)unit);
+                return jenkinsBatch;
+            }
+            else
+            {
+                return unit;
+            }
+        }
+
+        private ITestable Build(string curr, string appname, Size viewport, Batch flatBatch)
+        {
+            if (appname == null)
+            {
+                appname = "ImageTester";
+            }
+
+            var attr = File.GetAttributes(curr);
+            if (!attr.HasFlag(FileAttributes.Directory))
+            {
+                var fileStream = File.OpenRead(curr);
+                if (PDFTest.Supports(fileStream))
+                {
+                    PDFTest pdftest = new PDFTest(fileStream, this.appname, pdfdpi_);
+                    pdftest.SetPdfPassword(pdfPassword_);
+                    pdftest.SetPages(pages_);
+                    return pdftest;
+                }
+
+                //TODO: Implement
+                //if (PostscriptTest.Supports(fileStream))
+                //{
+                //    PostscriptTest postScriptest = new PostscriptTest(fileStream, appname);
+                //    return postScriptest;
+                //}
+
+                return ImageStep.Supports(fileStream) ? new ImageStep(fileStream) : null;
+            }
+
+            Test currTest = null;
+            Batch currBatch = flatBatch;
+            Suite currSuite = null;
+            var supportedExtensions = PDFTest.SupportedExtensionsWithSeparator
+                .Concat(ImageStep.SupportedExtensionsWithSeparator);
+            var files = supportedExtensions
+                .AsParallel()
+                .SelectMany(p => Directory.EnumerateFiles(curr, "*" + p, SearchOption.AllDirectories))
+                .OrderBy(f => f);
+            foreach (var file in files)
+            {
+                var fileStream = File.OpenRead(file);
+                ITestable unit = Build(file, appname, viewport, flatBatch);
+                if (unit is ImageStep)
+                {
+                    if (currTest == null)
+                        currTest = new Test(fileStream, appname, viewport);
+                    ImageStep step = (ImageStep)unit;
+                    currTest.AddStep(step);
+                }
+                else if (unit is Test)
+                {
+                    if (currBatch == null)
+                        currBatch = new Batch(fileStream);
+                    currBatch.AddTest((Test)unit);
+                }
+                else if (flatBatch == null)
+                    if (unit is Batch)
+                    {
+                        if (currSuite == null)
+                            currSuite = new Suite(fileStream);
+                        currSuite.AddBatch((Batch)unit);
+                    }
+                    else if (unit is Suite)
+                    {
+                        Suite suite = (Suite)unit;
+                        if (currSuite == null)
+                            currSuite = new Suite(fileStream);
+                        suite.PortBatchesTo(currSuite);
+                        if (suite.HasOrphanTest())
+                        {
+                            if (currBatch == null)
+                                currBatch = new Batch(fileStream);
+                            suite.PortTestTo(currBatch);
+                        }
+                    }
+                    else
+                    {
+                    }
+            }
+
+            if (flatBatch == null)
+            {
+                if (currTest == null && currBatch == null && currSuite == null)
+                    return null;
+                if (currTest != null && currBatch == null && currSuite == null)
+                    return currTest;
+                if (currTest == null && currBatch != null && currSuite == null)
+                    return currBatch;
+                if (currTest == null && currBatch == null && currSuite != null)
+                    return currSuite;
+                if (currSuite == null)
+                    currSuite = new Suite(File.OpenRead(curr));
+                if (currBatch != null)
+                    currSuite.AddBatch(currBatch);
+                if (currTest != null)
+                    currSuite.SetTest(currTest);
+                return currSuite;
+            }
+            else if (currTest != null)
+                return currTest;
+            return currBatch;
+        }
+
+        public virtual string GetPdfPassword()
+        {
+            return pdfPassword_;
+        }
+
+        public virtual void SetPdfPassword(string pdfPassword)
+        {
+            this.pdfPassword_ = pdfPassword;
+        }
+    }
+}

--- a/Eyes/ImageTester/src/csharp/lib/TestObjects/Batch.cs
+++ b/Eyes/ImageTester/src/csharp/lib/TestObjects/Batch.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Applitools.Images;
+
+namespace Applitools.ImageTester.TestObjects
+{
+    public class Batch : TestUnit
+    {
+        private BatchInfo batch;
+        private readonly IList<Test> tests = new List<Test>();
+
+        public Batch(FileStream file) : base(file)
+        {
+        }
+
+        public Batch(BatchInfo batch) : base(batch.Name)
+        {
+            this.batch = batch;
+        }
+
+        public override void Run(Eyes eyes)
+        {
+            batch = batch == null ? new BatchInfo(Name()) : batch;
+            eyes.Batch = batch;
+            Console.WriteLine("Batch: {0}", Name());
+            foreach (var test in tests)
+            {
+                try
+                {
+                    test.Run(eyes);
+                }
+                finally
+                {
+                    test.Dispose();
+                }
+            }
+
+            eyes.Batch = null;
+        }
+
+        public virtual void AddTest(Test test)
+        {
+            tests.Add(test);
+        }
+
+        public override void Dispose()
+        {
+            if (tests == null)
+            {
+                return;
+            }
+
+            foreach (var test in tests)
+            {
+                test.Dispose();
+            }
+        }
+    }
+}

--- a/Eyes/ImageTester/src/csharp/lib/TestObjects/Batch.cs
+++ b/Eyes/ImageTester/src/csharp/lib/TestObjects/Batch.cs
@@ -35,7 +35,6 @@ namespace Applitools.ImageTester.TestObjects
                     test.Dispose();
                 }
             }
-
             eyes.Batch = null;
         }
 

--- a/Eyes/ImageTester/src/csharp/lib/TestObjects/ImageStep.cs
+++ b/Eyes/ImageTester/src/csharp/lib/TestObjects/ImageStep.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using Applitools.Images;
+
+namespace Applitools.ImageTester.TestObjects
+{
+    public class ImageStep : TestUnit
+    {
+        private Bitmap img_;
+
+        public static string[] SupportedExtensionsWithSeparator { get; } = new[] { ".jpg", ".png",".gif", ".bmp" };
+
+        public ImageStep(FileStream file) : base(file)
+        {
+        }
+
+        public override void Run(Eyes eyes)
+        {
+            try
+            {
+                eyes.CheckImage(GetImage(), Name());
+            }
+            catch (IOException e)
+            {
+                Console.WriteLine("Failed to process image file: {0} \\n Reason: {1} \\n", file.Name, e.Message);
+                throw;
+            }
+        }
+
+        public virtual Bitmap GetImage()
+        {
+            if (img_ == null)
+            {
+                img_ = new Bitmap(file);
+            }
+
+            return img_;
+        }
+
+        public override string Name()
+        {
+            return Path.GetFileNameWithoutExtension(base.Name());
+        }
+
+        public static bool Supports(FileStream file)
+        {
+            return SupportedExtensionsWithSeparator
+                .AsParallel()
+                .Any(e => file.Name.EndsWith(e));
+        }
+
+        public override void Dispose()
+        {
+            img_?.Dispose();
+        }
+    }
+}

--- a/Eyes/ImageTester/src/csharp/lib/TestObjects/PDFTest.cs
+++ b/Eyes/ImageTester/src/csharp/lib/TestObjects/PDFTest.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using Applitools.Images;
+using PdfiumViewer;
+
+namespace Applitools.ImageTester.TestObjects
+{
+    public class PDFTest : Test
+    {
+        private float dpi;
+        private string pdfPassword;
+        private List<int> pagesList;
+        private string pages;
+
+        public static string[] SupportedExtensionsWithSeparator { get; } = new[] { ".pdf" };
+
+        public virtual void SetPages(string pages)
+        {
+            this.pages = pages;
+            this.pagesList = SetPagesList(pages);
+        }
+
+        protected PDFTest(FileStream file, string appname) : this(file, appname, 300F)
+        {
+        }
+
+        public PDFTest(FileStream file, string appname, float dpi) : base(file, appname)
+        {
+            this.dpi = dpi;
+        }
+
+        public override void Run(Eyes eyes)
+        {
+            Exception ex = null;
+            TestResults result = null;
+            try
+            {
+                var pdfDocument = PdfDocument.Load(this.file, pdfPassword);
+                eyes.Open(appname, Name());
+                for (int i = 0; i < pagesList.Count; i++)
+                {
+                    var bim = pdfDocument.Render(pagesList[i] - 1, this.dpi, this.dpi, false);
+                    eyes.CheckImage(new Bitmap(bim), string.Format("Page-{0}", pagesList[i]));
+                }
+
+                result = eyes.Close(false);
+                PrintTestResults(result);
+                HandleResultsDownload(result);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.StackTrace);
+            }
+            finally
+            {
+                eyes.AbortIfNotClosed();
+            }
+        }
+
+        public static bool Supports(FileStream file)
+        {
+            return SupportedExtensionsWithSeparator
+                .AsParallel()
+                .Any(e => file.Name.EndsWith(e));
+        }
+
+        protected virtual void SetDpi(float dpi)
+        {
+            this.dpi = dpi;
+        }
+
+        public virtual string GetPdfPassword()
+        {
+            return pdfPassword;
+        }
+
+        public virtual void SetPdfPassword(string pdfPassword)
+        {
+            this.pdfPassword = pdfPassword;
+        }
+
+        public virtual List<int> SetPagesList(string pages)
+        {
+            if (pages != null)
+                return ParsePagesToList(pages);
+            else
+            {
+                var pdfDocument = PdfDocument.Load(this.file, pdfPassword);
+                var list = new List<int>();
+                for (int page = 0; page < pdfDocument.PageCount; ++page)
+                {
+                    list.Add(page + 1);
+                }
+
+                return list;
+            }
+        }
+
+        public override string Name()
+        {
+            string pagesText = "";
+            if (pages != null)
+                pagesText = " pages [" + pages + "]";
+            return file == null ? name + pagesText : file.Name + pagesText;
+        }
+    }
+}

--- a/Eyes/ImageTester/src/csharp/lib/TestObjects/PDFTest.cs
+++ b/Eyes/ImageTester/src/csharp/lib/TestObjects/PDFTest.cs
@@ -34,30 +34,14 @@ namespace Applitools.ImageTester.TestObjects
 
         public override void Run(Eyes eyes)
         {
-            Exception ex = null;
-            TestResults result = null;
-            try
-            {
-                var pdfDocument = PdfDocument.Load(this.file, pdfPassword);
-                eyes.Open(appname, Name());
-                for (int i = 0; i < pagesList.Count; i++)
-                {
-                    var bim = pdfDocument.Render(pagesList[i] - 1, this.dpi, this.dpi, false);
-                    eyes.CheckImage(new Bitmap(bim), string.Format("Page-{0}", pagesList[i]));
-                }
+            var pdfDocument = PdfDocument.Load(this.file, pdfPassword);
 
-                result = eyes.Close(false);
-                PrintTestResults(result);
-                HandleResultsDownload(result);
-            }
-            catch (Exception e)
+            for (int i = 0; i < pagesList.Count; i++)
             {
-                Console.WriteLine(e.StackTrace);
+                var bim = pdfDocument.Render(pagesList[i] - 1, this.dpi, this.dpi, false);
+                eyes.CheckImage(new Bitmap(bim), string.Format("Page-{0}", pagesList[i]));
             }
-            finally
-            {
-                eyes.AbortIfNotClosed();
-            }
+
         }
 
         public static bool Supports(FileStream file)
@@ -85,7 +69,9 @@ namespace Applitools.ImageTester.TestObjects
         public virtual List<int> SetPagesList(string pages)
         {
             if (pages != null)
+            {
                 return ParsePagesToList(pages);
+            }
             else
             {
                 var pdfDocument = PdfDocument.Load(this.file, pdfPassword);
@@ -103,7 +89,10 @@ namespace Applitools.ImageTester.TestObjects
         {
             string pagesText = "";
             if (pages != null)
+            {
                 pagesText = " pages [" + pages + "]";
+            }
+
             return file == null ? name + pagesText : file.Name + pagesText;
         }
     }

--- a/Eyes/ImageTester/src/csharp/lib/TestObjects/Suite.cs
+++ b/Eyes/ImageTester/src/csharp/lib/TestObjects/Suite.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Applitools.Images;
+
+namespace Applitools.ImageTester.TestObjects
+{
+    public class Suite : TestUnit
+    {
+        private IList<Batch> batches;
+        private Test test_ = null;
+
+        public Suite(FileStream file) : base(file)
+        {
+            batches = new List<Batch>();
+        }
+
+        public override void Run(Eyes eyes)
+        {
+            if (!batches.Any() || test_ == null)
+            {
+                Console.WriteLine("Nothing to test!");
+                return;
+            }
+
+            foreach (Batch batch in batches)
+            {
+                try
+                {
+                    batch.Run(eyes);
+                }
+                finally
+                {
+                    batch.Dispose();
+                }
+            }
+
+            Console.WriteLine("> No batch <");
+            test_.Run(eyes);
+        }
+
+        public virtual void AddBatch(Batch batch)
+        {
+            batches.Add(batch);
+        }
+
+        public virtual void PortBatchesTo(Suite destination)
+        {
+            destination.batches = destination.batches.Concat(batches).ToList();
+            batches.Clear();
+        }
+
+        public virtual void PortTestTo(Batch destination)
+        {
+            destination.AddTest(test_);
+            test_ = null;
+        }
+
+        public virtual bool HasOrphanTest()
+        {
+            return test_ != null;
+        }
+
+        public virtual void SetTest(Test test)
+        {
+            if (test_ != null)
+            {
+                throw new ArgumentException("test is not null as expected!");
+            }
+
+            test_ = test;
+        }
+
+        public override void Dispose()
+        {
+            test_?.Dispose();
+        }
+    }
+}

--- a/Eyes/ImageTester/src/csharp/lib/TestObjects/Test.cs
+++ b/Eyes/ImageTester/src/csharp/lib/TestObjects/Test.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using Applitools.Images;
+using Applitools.ImageTester.Interfaces;
+
+namespace Applitools.ImageTester.TestObjects
+{
+    public class Test : TestUnit
+    {
+        protected readonly string appname;
+        protected Size viewportSize;
+        private readonly IList<ITestable> steps;
+
+        public Test(FileStream file, string appname) : this(file, appname, Size.Empty)
+        {
+        }
+
+        public Test(FileStream file, string appname, Size viewportSize) : base(file)
+        {
+            steps = new List<ITestable>();
+            this.appname = appname;
+            this.viewportSize = viewportSize;
+        }
+
+        public override void Run(Eyes eyes)
+        {
+            eyes.Open(appname, Name(), viewportSize);
+            foreach (ITestable step in steps)
+            {
+                try
+                {
+                    step.Run(eyes);
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(string.Format("Error in Step {0}: \\n {1} \\n This step will be skipped!", step.Name(), e.Message));
+                    Console.WriteLine(e.StackTrace);
+                }
+            }
+
+            try
+            {
+                TestResults result = eyes.Close(false);
+                PrintTestResults(result);
+                HandleResultsDownload(result);
+            }
+            catch (EyesException e)
+            {
+                Console.WriteLine(string.Format("Error closing test {0} \\nPath: {1} \\nReason: {2}", Name(), file.Name, e.Message));
+                Console.WriteLine("Aborting...");
+                try
+                {
+                    eyes.AbortIfNotClosed();
+                    Console.WriteLine("Aborted!");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(string.Format("Error while aborting: {0}", ex.Message));
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+            }
+        }
+
+        protected virtual void HandleResultsDownload(TestResults results)
+        {
+        }
+
+        public virtual void AddStep(ITestable step)
+        {
+            steps.Add(step);
+        }
+
+        public virtual void AddSteps(IList<ITestable> steps)
+        {
+            foreach (var step in steps)
+            {
+                AddStep(step);
+            }
+        }
+
+        protected virtual void PrintTestResults(TestResults result)
+        {
+            string res = "Empty";
+            if (result.Steps > 0)
+            {
+                if (result.IsNew)
+                {
+                    res = "New";
+                }
+                else if (result.IsPassed)
+                {
+                    res = "Passed";
+                }
+                else
+                {
+                    res = "Failed";
+                }
+            }
+
+            Console.WriteLine(string.Format("\\t[{0}] - {1}", res, Name()));
+            if (!result.IsPassed && !result.IsNew)
+            {
+                Console.WriteLine(string.Format("\\tResult url: {0}", result.Url));
+            }
+        }
+
+        protected static List<int> ParsePagesToList(string input)
+        {
+            if (input == null)
+            {
+                return new List<int>();
+            }
+
+            var pagesToInclude = new List<int>();
+            var inputPages = input.Split(',');
+            for (int i = 0; i < inputPages.Length; i++)
+            {
+                if (inputPages[i].Contains("-"))
+                {
+                    int left = int.Parse(inputPages[i].Split('-')[0]);
+                    int right = int.Parse(inputPages[i].Split('-')[1]);
+                    if (left <= right)
+                    {
+                        for (int j = left; j <= right; j++)
+                        {
+                            pagesToInclude.Add(j);
+                        }
+                    }
+                    else
+                    {
+                        for (int j = left; j >= right; j--)
+                        {
+                            pagesToInclude.Add(j);
+                        }
+                    }
+                }
+                else
+                {
+                    pagesToInclude.Add(int.Parse(inputPages[i]));
+                }
+            }
+
+            return pagesToInclude;
+        }
+
+        public override void Dispose()
+        {
+            if (steps == null)
+                return;
+            foreach (ITestable step in steps)
+            {
+                step?.Dispose();
+            }
+        }
+    }
+}

--- a/Eyes/ImageTester/src/csharp/lib/TestObjects/Test.cs
+++ b/Eyes/ImageTester/src/csharp/lib/TestObjects/Test.cs
@@ -26,7 +26,6 @@ namespace Applitools.ImageTester.TestObjects
 
         public override void Run(Eyes eyes)
         {
-            eyes.Open(appname, Name(), viewportSize);
             foreach (ITestable step in steps)
             {
                 try
@@ -38,31 +37,6 @@ namespace Applitools.ImageTester.TestObjects
                     Console.WriteLine(string.Format("Error in Step {0}: \\n {1} \\n This step will be skipped!", step.Name(), e.Message));
                     Console.WriteLine(e.StackTrace);
                 }
-            }
-
-            try
-            {
-                TestResults result = eyes.Close(false);
-                PrintTestResults(result);
-                HandleResultsDownload(result);
-            }
-            catch (EyesException e)
-            {
-                Console.WriteLine(string.Format("Error closing test {0} \\nPath: {1} \\nReason: {2}", Name(), file.Name, e.Message));
-                Console.WriteLine("Aborting...");
-                try
-                {
-                    eyes.AbortIfNotClosed();
-                    Console.WriteLine("Aborted!");
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine(string.Format("Error while aborting: {0}", ex.Message));
-                }
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e.Message);
             }
         }
 

--- a/Eyes/ImageTester/src/csharp/lib/TestObjects/TestUnit.cs
+++ b/Eyes/ImageTester/src/csharp/lib/TestObjects/TestUnit.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+using Applitools.Images;
+using Applitools.ImageTester.Interfaces;
+
+namespace Applitools.ImageTester.TestObjects
+{
+    public abstract class TestUnit : ITestable
+    {
+        protected readonly FileStream file;
+        protected string name;
+
+        protected TestUnit(FileStream file)
+        {
+            this.file = file;
+            if (file != null && !file.CanRead)
+            {
+                throw new InvalidOperationException(string.Format("Unreadable path/file '{0}', might be a permission issue!", file.Name));
+            }
+        }
+
+        protected TestUnit(string name)
+        {
+            file = null;
+            this.name = name;
+        }
+
+        public virtual string Name()
+        {
+            return file == null ? name : file.Name;
+        }
+
+        public virtual FileStream GetFile()
+        {
+            return file;
+        }
+
+        public abstract void Run(Eyes eyes);
+
+        public abstract void Dispose();
+    }
+}

--- a/Eyes/ImageTester/src/csharp/lib/app.config
+++ b/Eyes/ImageTester/src/csharp/lib/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Eyes/ImageTester/src/csharp/lib/packages.config
+++ b/Eyes/ImageTester/src/csharp/lib/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="DotNetZip.Reduced" version="1.9.1.8" targetFramework="net452" />
+  <package id="Eyes.Images" version="1.22.0" targetFramework="net452" />
+  <package id="Eyes.Sdk" version="2.5.3" targetFramework="net452" />
+  <package id="ILRepack.MSBuild.Task" version="1.0.9" targetFramework="net452" />
+  <package id="log4net" version="2.0.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net452" />
+  <package id="PdfiumViewer" version="2.12.0.0" targetFramework="net452" />
+  <package id="PdfiumViewer.Native.x86.v8-xfa" version="2018.4.8.256" targetFramework="net452" />
+  <package id="PdfiumViewer.Native.x86_64.v8-xfa" version="2018.4.8.256" targetFramework="net452" />
+</packages>

--- a/Eyes/ImageTester/src/csharp/main/App.config
+++ b/Eyes/ImageTester/src/csharp/main/App.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Eyes/ImageTester/src/csharp/main/Applitools.ImageTester.Runner.csproj
+++ b/Eyes/ImageTester/src/csharp/main/Applitools.ImageTester.Runner.csproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B21498AD-E651-4738-9A72-1156D0F7871D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Applitools.ImageTester</RootNamespace>
+    <AssemblyName>ImageTester</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="CommandLine, Version=2.2.1.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.2.1\lib\net45\CommandLine.dll</HintPath>
+    </Reference>
+    <Reference Include="Eyes.Bundle, Version=1.22.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\bin\Release\Eyes.Bundle.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\lib\Applitools.ImageTester.csproj">
+      <Project>{CD3852A3-83F4-42D2-A109-9D3DA663691A}</Project>
+      <Name>Applitools.ImageTester</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Eyes/ImageTester/src/csharp/main/Program.cs
+++ b/Eyes/ImageTester/src/csharp/main/Program.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Drawing;
+using System.IO;
+using Applitools.Images;
+using Applitools.ImageTester;
+using CommandLine;
+
+namespace Applitools.ImageTester
+{
+    public static class ImageTester
+    {
+        internal static readonly log4net.LogManager mgr = null; // explicit ref
+
+        public static void Main(string[] args)
+        {
+            Options options = null;
+            Parser.Default.ParseArguments<Options>(args)
+                   .WithParsed(opts => options = opts);
+            if (options == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var eyes = new Eyes();
+
+                // API key
+                eyes.ApiKey = options.ApiKey;
+                // Applitools Server url
+                if (options.ServerUrl != null)
+                {
+                    eyes.ServerUrl = options.ServerUrl.ToString();
+                }
+                // Match level
+                eyes.MatchLevel = options.MatchLevel;
+                //TODO: Proxy
+                //TODO: Branch name
+                //TODO: Parent branch
+                //TODO: Baseline name
+                //TODO: Log file
+                //TODO: host os
+                //TODO: host app
+                //TODO: Set failed tests
+                // Viewport size
+                var viewPortSize = new Size(1920, 1080);
+                var vs = options.ViewPortSize?.Split('x');
+                if (vs?.Length == 2)
+                {
+                    viewPortSize = new Size(int.Parse(vs[0]), int.Parse(vs[1]));
+                }
+                // Folder path
+                var root = Path.GetFullPath(options.Folder);
+
+                var builder = new SuiteBuilder(root, options.AppName, viewPortSize);
+                //TODO: DPI
+                //TODO: Determine Pages to include
+                //TODO: Read PDF Password
+
+                //TODO: if utils_enabled builder.setEyesUtilitiesConfig
+
+                var suite = builder.Build();
+                if (suite == null)
+                {
+                    Console.WriteLine("Nothing to test!");
+                    return;
+                }
+
+                suite.Run(eyes);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.StackTrace);
+            }
+        }
+
+        private sealed class Options
+        {
+            [Option('k', Required = true, HelpText = "Applitools api key")]
+            public string ApiKey { get; set; }
+
+            [Option('a', Required = false, HelpText = "Set own application name, default: ImageTester", Default = "ImageTester")]
+            public string AppName { get; set; }
+
+            [Option('f', Required = false, HelpText = "Set the root folder to start the analysis, default is the current directory", Default = ".")]
+            public string Folder { get; set; }
+
+            //TODO: Implement proxy
+
+            [Option('s', Required = false, HelpText = "Set Applitools server url")]
+            public Uri ServerUrl { get; set; }
+
+            [Option("ml", Required = false, HelpText = "Set match level to one of [%s], default = Strict", Default = MatchLevel.Strict)]
+            public MatchLevel MatchLevel { get; set; }
+
+            //TODO: Implement branch, parentBranch, baseline
+
+            [Option("vs", Required = false, HelpText = "Declare viewport size identifier <width>x<height> ie. 1000x600, if not set,default will be the first image in every test")]
+            public string ViewPortSize { get; set; }
+
+            //TODO: Implement logFile, autoSave, hostOs, hostApp, dpi, selectedPages, PDFPassword
+            //TODO: Implement extra features are available case: viewKey, outFolder, getDiffs, getImages, getGifs
+        }
+    }
+}

--- a/Eyes/ImageTester/src/csharp/main/Properties/AssemblyInfo.cs
+++ b/Eyes/ImageTester/src/csharp/main/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Main")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Main")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b21498ad-e651-4738-9a72-1156d0f7871d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Eyes/ImageTester/src/csharp/main/packages.config
+++ b/Eyes/ImageTester/src/csharp/main/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CommandLineParser" version="2.2.1" targetFramework="net452" />
+  <package id="DotNetZip.Reduced" version="1.9.1.8" targetFramework="net452" />
+  <package id="Eyes.Images" version="1.22.0" targetFramework="net452" />
+  <package id="Eyes.Sdk" version="2.5.3" targetFramework="net452" />
+  <package id="log4net" version="2.0.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net452" />
+</packages>

--- a/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/EyesUtilitiesConfig.java
+++ b/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/EyesUtilitiesConfig.java
@@ -1,0 +1,80 @@
+package com.applitools.ImageTester;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.ParseException;
+
+/**
+ * Created by liranbarokas on 08/05/2017.
+ */
+public class EyesUtilitiesConfig {
+
+    private String viewKey_;
+    private String destinationFolder_;
+    private Boolean downloadDiffs_ = false;
+    private Boolean getImages_ = false;
+    private Boolean getGifs_ = false;
+
+
+    private EyesUtilitiesConfig(String viewKey, String destinationFolder, Boolean downloadDiffs, Boolean getImages, Boolean getGifs) {
+        viewKey_ = viewKey;
+        destinationFolder_ = destinationFolder;
+        downloadDiffs_ = downloadDiffs;
+        getImages_ = getImages;
+        getGifs_ = getGifs;
+    }
+
+    public EyesUtilitiesConfig(CommandLine cmd) throws ParseException {
+        if (cmd.hasOption("gd") || cmd.hasOption("gi") || cmd.hasOption("gg")) {
+            if (!cmd.hasOption("vk"))
+                throw new ParseException("gd|gi|gg must be called with enterprise view-key (vk)");
+            viewKey_ = cmd.getOptionValue("vk");
+            destinationFolder_ = cmd.getOptionValue("of", "./");
+            downloadDiffs_ = cmd.hasOption("gd");
+            getImages_ = cmd.hasOption("gi");
+            getGifs_ = cmd.hasOption("gg");
+        }
+    }
+
+
+    public String getViewKey() {
+        return viewKey_;
+    }
+
+    public void setViewKey(String viewKey) {
+        this.viewKey_ = viewKey;
+    }
+
+    public String getDestinationFolder() {
+        return destinationFolder_;
+    }
+
+    public void setDestinationFolder(String destinationFolder) {
+        this.destinationFolder_ = destinationFolder;
+    }
+
+    public Boolean getDownloadDiffs() {
+        return downloadDiffs_;
+    }
+
+    public void setDownloadDiffs(Boolean downloadDiffs) {
+        this.downloadDiffs_ = downloadDiffs;
+    }
+
+    public Boolean getGetImages() {
+        return getImages_;
+    }
+
+    public void setGetImages(Boolean getImages) {
+        this.getImages_ = getImages;
+    }
+
+    public Boolean getGetGifs() {
+        return getGifs_;
+    }
+
+    public void setGetGifs(Boolean getGifs) {
+        this.getGifs_ = getGifs;
+    }
+
+
+}

--- a/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/Interfaces/IDisposable.java
+++ b/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/Interfaces/IDisposable.java
@@ -1,0 +1,8 @@
+package com.applitools.ImageTester.Interfaces;
+
+/**
+ * Created by yanir on 21/06/2017.
+ */
+public interface IDisposable {
+    void dispose();
+}

--- a/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/Interfaces/ITestable.java
+++ b/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/Interfaces/ITestable.java
@@ -1,0 +1,12 @@
+package com.applitools.ImageTester.Interfaces;
+
+
+import com.applitools.eyes.images.Eyes;
+
+import java.io.IOException;
+
+public interface ITestable {
+    void run(Eyes eyes) throws IOException;
+
+    String name();
+}

--- a/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/MatchLevels.java
+++ b/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/MatchLevels.java
@@ -1,0 +1,11 @@
+package com.applitools.ImageTester;
+
+/**
+ * Created by yanir on 23/04/2016.
+ */
+public enum MatchLevels {
+    Strict,
+    Layout,
+    Layout2,
+    Content
+}

--- a/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/Patterns.java
+++ b/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/Patterns.java
@@ -1,0 +1,15 @@
+package com.applitools.ImageTester;
+
+import java.util.regex.Pattern;
+
+/**
+ * Created by yanir on 01/09/2016.
+ */
+public abstract class Patterns {
+    public static final String IMAGE_EXT = "(\\.(?i)(jpg|png|gif|bmp))$";
+    private static final String IMAGE_PATTERN = "(.+)" + IMAGE_EXT;
+    public static final Pattern IMAGE = Pattern.compile(IMAGE_PATTERN);
+    private static final String PDF_EXT = "(?i)(\\.Pdf)$";
+    private static final String PDF_PATTERN = "(.+)" + PDF_EXT;
+    public static final Pattern PDF = Pattern.compile(PDF_PATTERN);
+}

--- a/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/SuiteBuilder.java
+++ b/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/SuiteBuilder.java
@@ -1,0 +1,168 @@
+package com.applitools.ImageTester;
+
+import com.applitools.ImageTester.Interfaces.ITestable;
+import com.applitools.ImageTester.TestObjects.*;
+import com.applitools.eyes.BatchInfo;
+import com.applitools.eyes.RectangleSize;
+import org.apache.commons.io.comparator.NameFileComparator;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class SuiteBuilder {
+    private File rootFolder_;
+    private String appname_;
+    private RectangleSize viewport_;
+    private EyesUtilitiesConfig eyesUtilitiesConfig_;
+    private float pdfdpi_;
+    private String pdfPassword_;
+    private String pages_;
+
+    public String getPages() {
+        return pages_;
+    }
+
+    public void setPages(String steps) {
+        this.pages_ = steps;
+    }
+
+    public EyesUtilitiesConfig getEyesUtilitiesConfig() {
+        return eyesUtilitiesConfig_;
+    }
+
+    public void setEyesUtilitiesConfig(EyesUtilitiesConfig eyesUtilitiesConfig) {
+        this.eyesUtilitiesConfig_ = eyesUtilitiesConfig;
+    }
+
+
+    public SuiteBuilder(File rootFolder, String appname, RectangleSize viewport) {
+        this.rootFolder_ = rootFolder;
+        this.appname_ = appname;
+        this.viewport_ = viewport;
+    }
+
+    public ITestable build() throws IOException {
+        return build(rootFolder_, appname_, viewport_);
+    }
+
+    public void setDpi(float dpi) {
+        this.pdfdpi_ = dpi;
+    }
+
+    private ITestable build(File curr, String appname, RectangleSize viewport) throws IOException {
+        String jenkinsJobName = System.getenv("JOB_NAME");
+        String jenkinsApplitoolsBatchId = System.getenv("APPLITOOLS_BATCH_ID");
+        Batch jenkinsBatch = null;
+
+        if ((jenkinsJobName != null) && (jenkinsApplitoolsBatchId != null)) {
+            BatchInfo batch = new BatchInfo(jenkinsJobName);
+            batch.setId(jenkinsApplitoolsBatchId);
+            jenkinsBatch = new Batch(batch);
+        }
+        ITestable unit = build(curr, appname, viewport, jenkinsBatch);
+        if (unit instanceof ImageStep) {
+            ImageStep step = (ImageStep) unit;
+            Test test = new Test(step.getFile(), appname, viewport_);
+            test.setEyesUtilitiesConfig(eyesUtilitiesConfig_);
+            test.addStep(step);
+            unit = test;
+        }
+        if (unit instanceof Test && jenkinsBatch != null) {
+            jenkinsBatch.addTest((Test) unit);
+            return jenkinsBatch;
+        } else {
+            return unit;
+        }
+    }
+
+    private ITestable build(File curr, String appname, RectangleSize viewport, Batch flatBatch) throws IOException {
+        if (!curr.exists()) {
+            System.out.printf(String.format("The folder %s doesn't exists\n", curr.getAbsolutePath()));
+            return null;
+        }
+
+        if (appname == null) {
+            appname = "ImageTester";
+        }
+
+        if (curr.isFile()) {
+            if (PDFTest.supports(curr)) {
+                PDFTest pdftest = new PDFTest(curr, appname_, pdfdpi_, viewport);
+                pdftest.setEyesUtilitiesConfig(eyesUtilitiesConfig_);
+                pdftest.setPages(pages_);
+                pdftest.setPdfPassword(pdfPassword_);
+                return pdftest;
+            }
+            if (PostscriptTest.supports(curr)) {
+                PostscriptTest postScriptest = new PostscriptTest(curr, appname);
+                postScriptest.setEyesUtilitiesConfig(eyesUtilitiesConfig_);
+                return postScriptest;
+            }
+            return ImageStep.supports(curr) ? new ImageStep(curr) : null;
+        }
+
+        Test currTest = null;
+        Batch currBatch = flatBatch;
+        Suite currSuite = null;
+
+        File[] files = curr.listFiles();
+        Arrays.sort(files, NameFileComparator.NAME_COMPARATOR);
+
+        for (File file : files) {
+            ITestable unit = build(file, appname, viewport, flatBatch);
+            if (unit instanceof ImageStep) {
+                if (currTest == null) currTest = new Test(curr, appname, viewport);
+                currTest.setEyesUtilitiesConfig(eyesUtilitiesConfig_);
+                ImageStep step = (ImageStep) unit;
+                if (step.hasRegionFile())
+                    currTest.addSteps(step.getRegions());
+                else
+                    currTest.addStep(step);
+            } else if (unit instanceof Test) {
+                if (currBatch == null) currBatch = new Batch(curr);
+                currBatch.addTest((Test) unit);
+            } else if (flatBatch == null)
+                if (unit instanceof Batch) {
+                    if (currSuite == null) currSuite = new Suite(curr);
+                    currSuite.addBatch((Batch) unit);
+                } else if (unit instanceof Suite) {
+                    Suite suite = (Suite) unit;
+                    if (currSuite == null) currSuite = new Suite(curr);
+                    suite.portBatchesTo(currSuite);
+                    if (suite.hasOrphanTest()) {
+                        if (currBatch == null) currBatch = new Batch(curr);
+                        suite.portTestTo(currBatch);
+                    }
+                } else {
+                    //SKIP
+                }
+        }
+
+        if (flatBatch == null) {
+            //Simple cases
+            if (currTest == null && currBatch == null && currSuite == null) return null;
+            if (currTest != null && currBatch == null && currSuite == null) return currTest;
+            if (currTest == null && currBatch != null && currSuite == null) return currBatch;
+            if (currTest == null && currBatch == null && currSuite != null) return currSuite;
+
+            //The complicated case
+            if (currSuite == null) currSuite = new Suite(curr);
+            if (currBatch != null) currSuite.addBatch(currBatch);
+            if (currTest != null) currSuite.setTest(currTest);
+
+            return currSuite;
+        } else if (currTest != null)
+            return currTest;
+
+        return currBatch;
+    }
+
+    public String getPdfPassword() {
+        return pdfPassword_;
+    }
+
+    public void setPdfPassword(String pdfPassword) {
+        this.pdfPassword_ = pdfPassword;
+    }
+}

--- a/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/Batch.java
+++ b/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/Batch.java
@@ -1,0 +1,47 @@
+package com.applitools.ImageTester.TestObjects;
+
+import com.applitools.eyes.BatchInfo;
+import com.applitools.eyes.images.Eyes;
+
+import java.io.File;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class Batch extends TestUnit {
+    private BatchInfo batch_;
+    private Queue<Test> tests_ = new LinkedList<Test>();
+
+    public Batch(File file) {
+        super(file);
+    }
+
+    public Batch(BatchInfo batch) {
+        super(batch.getName());
+        batch_ = batch;
+    }
+
+    public void run(Eyes eyes) {
+        batch_ = batch_ == null ? new BatchInfo(name()) : batch_;
+        eyes.setBatch(batch_);
+        System.out.printf("Batch: %s\n", name());
+        for (Test test : tests_) {
+            try {
+                test.run(eyes);
+            } finally {
+                test.dispose();
+            }
+        }
+        eyes.setBatch(null);
+    }
+
+    public void addTest(Test test) {
+        tests_.add(test);
+    }
+
+    public void dispose() {
+        if (tests_ == null) return;
+        for (Test test : tests_) {
+            test.dispose();
+        }
+    }
+}

--- a/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/ImageStep.java
+++ b/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/ImageStep.java
@@ -1,0 +1,60 @@
+package com.applitools.ImageTester.TestObjects;
+
+import com.applitools.ImageTester.Interfaces.ITestable;
+import com.applitools.ImageTester.Patterns;
+import com.applitools.eyes.images.Eyes;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.regex.Pattern;
+
+public class ImageStep extends TestUnit {
+    private static final Pattern pattern = Patterns.IMAGE;
+    private BufferedImage img_;
+
+    public ImageStep(File file) {
+        super(file);
+    }
+
+    public void run(Eyes eyes) throws IOException {
+        try {
+            eyes.checkImage(getImage(), name());
+        } catch (IOException e) {
+            System.out.printf("Failed to process image file: %s \n Reason: %s \n",
+                    file_,
+                    e.getMessage());
+            throw e;
+        }
+    }
+
+    public BufferedImage getImage() throws IOException {
+        if (img_ == null) {
+            img_ = ImageIO.read(file_);
+        }
+        return img_;
+    }
+
+    @Override
+    public String name() {
+        return super.name().replaceAll(Patterns.IMAGE_EXT, "");
+    }
+
+    public static boolean supports(File file) {
+        return pattern.matcher(file.getName()).matches();
+    }
+
+    public boolean hasRegionFile() {
+        return RegionStep.supports(this);
+    }
+
+    public Collection<ITestable> getRegions() throws IOException {
+        return RegionStep.getSteps(this);
+    }
+
+    public void dispose() {
+        if (img_ != null) img_ = null;
+    }
+}

--- a/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/PDFTest.java
+++ b/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/PDFTest.java
@@ -1,0 +1,107 @@
+package com.applitools.ImageTester.TestObjects;
+
+import com.applitools.ImageTester.Patterns;
+import com.applitools.eyes.TestResults;
+import com.applitools.eyes.images.Eyes;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Created by yanir on 30/01/2016.
+ */
+public class PDFTest extends Test {
+    private static final Pattern pattern = Patterns.PDF;
+    private float dpi_;
+    private String pdfPassword;
+    private List<Integer> pagesList_;
+    private String pages_;
+
+    public void setPages(String pages) throws IOException {
+        this.pages_ = pages;
+        this.pagesList_ = setPagesList(pages);
+    }
+
+    protected PDFTest(File file, String appname) {
+        this(file, appname, 300f);
+    }
+
+    public PDFTest(File file, String appname, float dpi) {
+        super(file, appname);
+        this.dpi_ = dpi;
+    }
+
+    @Override
+    public void run(Eyes eyes) {
+        Exception ex = null;
+        TestResults result = null;
+
+        try {
+            PDDocument document = PDDocument.load(file_, pdfPassword);
+            PDFRenderer pdfRenderer = new PDFRenderer(document);
+            eyes.open(appname_, name());
+
+            for (int i = 0; i < pagesList_.size(); i++) {
+                BufferedImage bim = pdfRenderer.renderImageWithDPI(pagesList_.get(i) - 1, dpi_);
+                eyes.checkImage(bim, String.format("Page-%s", pagesList_.get(i)));
+            }
+            result = eyes.close(false);
+            printTestResults(result);
+            handleResultsDownload(result);
+            document.close();
+        } catch (IOException e) {
+            ex = e;
+            System.out.printf("Error closing test %s \nPath: %s \nReason: %s \n", e.getMessage());
+
+        } catch (Exception e) {
+            System.out.println("Oops, something went wrong!");
+            System.out.print(e);
+            e.printStackTrace();
+        } finally {
+            if (ex != null) ex.printStackTrace();
+            eyes.abortIfNotClosed();
+        }
+    }
+
+    public static boolean supports(File file) {
+        return pattern.matcher(file.getName()).matches();
+    }
+
+    protected void setDpi(float dpi) {
+        this.dpi_ = dpi;
+    }
+
+    public String getPdfPassword() {
+        return pdfPassword;
+    }
+
+    public void setPdfPassword(String pdfPassword) {
+        this.pdfPassword = pdfPassword;
+    }
+
+    public List<Integer> setPagesList(String pages) throws IOException {
+        if (pages != null) return parsePagesToList(pages);
+        else {
+            PDDocument document = PDDocument.load(this.file_, this.pdfPassword);
+            PDFRenderer pdfRenderer = new PDFRenderer(document);
+            ArrayList<Integer> list = new ArrayList<Integer>();
+            for (int page = 0; page < document.getNumberOfPages(); ++page) {
+                list.add(page + 1);
+            }
+            return list;
+        }
+    }
+
+    @Override
+    public String name() {
+        String pagesText = "";
+        if (pages_ != null) pagesText = " pages [" + pages_ + "]";
+        return file_ == null ? name_ + pagesText : file_.getName() + pagesText;
+    }
+}

--- a/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/PostscriptTest.java
+++ b/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/PostscriptTest.java
@@ -1,0 +1,76 @@
+package com.applitools.ImageTester.TestObjects;
+
+import com.applitools.eyes.TestResults;
+import com.applitools.eyes.images.Eyes;
+import org.ghost4j.document.DocumentException;
+import org.ghost4j.document.PSDocument;
+import org.ghost4j.renderer.RendererException;
+import org.ghost4j.renderer.SimpleRenderer;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.regex.Pattern;
+import java.util.List;
+
+public class PostscriptTest extends Test {
+    private static final String PS_EXT = "(?i)(\\.ps)$";
+    private static final String PS_PATTERN = "(.+)" + PS_EXT;
+    private static final Pattern pattern = Pattern.compile(PS_PATTERN);
+
+    public PostscriptTest(File file, String appname) {
+        super(file, appname);
+    }
+
+    @Override
+    public void run(Eyes eyes) {
+        PSDocument document = new PSDocument();
+        SimpleRenderer renderer = new SimpleRenderer();
+        renderer.setResolution(300);
+        Exception ex = null;
+        String res = null;
+        TestResults result=null;
+        
+        try {
+            document.load(file_);
+            List<Image> images = renderer.render(document);
+
+            eyes.open(appname_, name());
+
+            int page = 1;
+            for (Image step : images) {
+                BufferedImage image = new BufferedImage(step.getWidth(null), step.getHeight(null), BufferedImage.TYPE_INT_ARGB);
+                eyes.checkImage(image, String.format("Page-%s", page++));
+            }
+
+            result = eyes.close(false);
+        } catch (FileNotFoundException e) {
+            res = "Error";
+            ex = e;
+        } catch (IOException e) {
+            res = "Error";
+            ex = e;
+        } catch (RendererException e) {
+            res = "Error";
+            ex = e;
+        } catch (DocumentException e) {
+            res = "Error";
+            ex = e;
+        } catch (UnsatisfiedLinkError e) {
+            System.out.printf("Please make sure tesseract is installed and in path!\n");
+            res = "Error";
+            e.printStackTrace();
+        } finally {
+            printTestResults(result);
+            if (ex != null) ex.printStackTrace();
+            eyes.abortIfNotClosed();
+        }
+    }
+
+    public static boolean supports(File file) {
+        return false;
+        //return pattern.matcher(file.getName()).matches();
+    }
+}

--- a/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/RegionStep.java
+++ b/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/RegionStep.java
@@ -1,0 +1,84 @@
+package com.applitools.ImageTester.TestObjects;
+
+import com.applitools.ImageTester.Interfaces.ITestable;
+import com.applitools.eyes.Region;
+import com.applitools.eyes.images.Eyes;
+import com.opencsv.CSVReader;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+
+public class RegionStep implements ITestable {
+    private static final String REGION_FILE_TMPL = "%s.regions";
+    private static final String STEP_FORMAT = "%s-%s";
+
+    private final ImageStep step_;
+    private final Region region_;
+    private final String tag_;
+
+    private RegionStep(ImageStep step, Region region, String tag) {
+        step_ = step;
+        region_ = region;
+        tag_ = tag;
+    }
+
+    public void run(Eyes eyes) throws IOException {
+        eyes.checkRegion(step_.getImage(), region_, tag_);
+    }
+
+    public String name() {
+        return String.format("Image: %s, region: %s", step_.name(), region_.toString());
+    }
+
+    public static boolean supports(ImageStep step) {
+        return regionsFile(step.file_).exists();
+    }
+
+    public static Collection<ITestable> getSteps(ImageStep step) throws IOException {
+        int stepno = 1;
+        List<ITestable> regions = new ArrayList<ITestable>();
+        File regionsFile = regionsFile(step.file_);
+        CSVReader reader = getReader(regionsFile);
+        List<String[]> lines = reader.readAll();
+        int l, t, w, h;
+        for (String[] line : lines) {
+            if (StringUtils.isEmpty(line[0])) {
+                regions.add(new ImageStep(step.file_));
+                continue;
+            } else if (line.length != 4) throw new IOException(
+                    "Invalid csv formatting for file " + regionsFile.getName() + " Should be left,top,width,height");
+
+            l = Integer.parseInt(line[0]);
+            t = Integer.parseInt(line[1]);
+            w = Integer.parseInt(line[2]);
+            h = Integer.parseInt(line[3]);
+            String stepName = String.format(STEP_FORMAT, step.name(), stepno);
+            regions.add(new RegionStep(step, new Region(l, t, w, h), stepName));
+            ++stepno;
+        }
+        return regions;
+    }
+
+    private static CSVReader getReader(File regionfile) {
+        try {
+            return new CSVReader(new FileReader(regionfile));
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+            throw new RuntimeException("This is a bug! Region file should be checked for existense");
+        }
+    }
+
+    private static File regionsFile(File imageFile) {
+        String regionFilePath = String.format(REGION_FILE_TMPL, FilenameUtils.removeExtension(imageFile.getName()));
+        regionFilePath = FilenameUtils.concat(imageFile.getParent(), regionFilePath);
+        return new File(regionFilePath);
+    }
+}

--- a/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/Suite.java
+++ b/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/Suite.java
@@ -1,0 +1,66 @@
+package com.applitools.ImageTester.TestObjects;
+
+
+import com.applitools.eyes.images.Eyes;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class Suite extends TestUnit {
+    private Queue<Batch> batches_;
+    private Test test_ = null;
+
+    public Suite(File file) {
+        super(file);
+        batches_ = new LinkedList<Batch>();
+    }
+
+    public void run(Eyes eyes) throws IOException {
+        if (batches_.isEmpty() && test_ == null) {
+            System.out.printf("Nothing to test!\n");
+            return;
+        }
+
+        for (Batch batch : batches_) {
+            try {
+                batch.run(eyes);
+            }finally {
+                batch.dispose();
+            }
+        }
+
+        if (test_ != null) {
+            System.out.printf("> No batch <\n");
+            test_.run(eyes);
+        }
+    }
+
+    public void addBatch(Batch batch) {
+        batches_.add(batch);
+    }
+
+    public void portBatchesTo(Suite destination) {
+        destination.batches_.addAll(batches_);
+        batches_.clear();
+    }
+
+    public void portTestTo(Batch destination) {
+        destination.addTest(test_);
+        test_ = null;
+    }
+
+    public boolean hasOrphanTest() {
+        return test_ != null;
+    }
+
+    public void setTest(Test test) {
+        if (test_ != null) throw new RuntimeException("test is not null as expected!");
+        test_ = test;
+    }
+
+    public void dispose() {
+        if (test_ != null) test_.dispose();
+    }
+}

--- a/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/Test.java
+++ b/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/Test.java
@@ -1,0 +1,148 @@
+package com.applitools.ImageTester.TestObjects;
+
+import com.applitools.Commands.AnimatedDiffs;
+import com.applitools.Commands.DownloadDiffs;
+import com.applitools.Commands.DownloadImages;
+import com.applitools.ImageTester.EyesUtilitiesConfig;
+import com.applitools.ImageTester.Interfaces.IDisposable;
+import com.applitools.ImageTester.Interfaces.ITestable;
+import com.applitools.eyes.EyesException;
+import com.applitools.eyes.RectangleSize;
+import com.applitools.eyes.TestResults;
+import com.applitools.eyes.images.Eyes;
+
+import java.io.File;
+import java.util.*;
+
+public class Test extends TestUnit {
+
+    protected final String appname_;
+    protected RectangleSize viewportSize_;
+    private Queue<ITestable> steps_;
+    private EyesUtilitiesConfig eyesUtilitiesConfig_;
+
+
+    public Test(File file, String appname) {
+        this(file, appname, null);
+    }
+
+    public Test(File file, String appname, RectangleSize viewportSize) {
+        super(file);
+        steps_ = new LinkedList<ITestable>();
+        appname_ = appname;
+        viewportSize_ = viewportSize;
+    }
+
+    public void run(Eyes eyes) {
+        eyes.open(appname_, name(), viewportSize_);
+        for (ITestable step : steps_) {
+            try {
+                step.run(eyes);
+                //Disposing steps without regions immediately
+                if (step instanceof IDisposable)
+                    if (!(step instanceof ImageStep && ((ImageStep) step).hasRegionFile()))
+                        ((IDisposable) step).dispose();
+            } catch (Throwable e) {
+                System.out.printf("Error in Step %s: \n %s \n This step will be skipped!", step.name(), e.getMessage());
+                e.printStackTrace();
+            }
+        }
+        try {
+            TestResults result = eyes.close(false);
+            printTestResults(result);
+            handleResultsDownload(result);
+        } catch (
+                EyesException e)
+
+        {
+            System.out.printf("Error closing test %s \nPath: %s \nReason: %s \n",
+                    name(),
+                    file_.getAbsolutePath(),
+                    e.getMessage());
+
+            System.out.println("Aborting...");
+            try {
+                eyes.abortIfNotClosed();
+                System.out.printf("Aborted!");
+            } catch (Throwable ex) {
+                System.out.printf("Error while aborting: %s", ex.getMessage());
+                System.out.println("I don't have any idea what just happened.");
+                System.out.println("Please try reaching our support at support@applitools.com");
+            }
+        } catch (
+                Exception e)
+
+        {
+            System.out.println("Oops, something went wrong!");
+            System.out.print(e);
+            e.printStackTrace();
+        }
+
+    }
+
+    protected void handleResultsDownload(TestResults results) throws Exception {
+        if (eyesUtilitiesConfig_ == null) return;
+        if (eyesUtilitiesConfig_.getDownloadDiffs() || eyesUtilitiesConfig_.getGetGifs() || eyesUtilitiesConfig_.getGetImages()) {
+            if (eyesUtilitiesConfig_.getViewKey() == null) throw new RuntimeException("The view-key cannot be null");
+            if (eyesUtilitiesConfig_.getDownloadDiffs() && !results.isNew() && !results.isPassed())
+                new DownloadDiffs(results.getUrl(), eyesUtilitiesConfig_.getDestinationFolder(), eyesUtilitiesConfig_.getViewKey()).run();
+            if (eyesUtilitiesConfig_.getGetGifs() && !results.isNew() && !results.isPassed())
+                new AnimatedDiffs(results.getUrl(), eyesUtilitiesConfig_.getDestinationFolder(), eyesUtilitiesConfig_.getViewKey()).run();
+            if (eyesUtilitiesConfig_.getGetImages())
+                new DownloadImages(results.getUrl(), eyesUtilitiesConfig_.getDestinationFolder(), eyesUtilitiesConfig_.getViewKey(), false, false).run();
+        }
+    }
+
+    public void addStep(ImageStep step) {
+        steps_.add(step);
+    }
+
+    public void addSteps(Collection<ITestable> steps) {
+        steps_.addAll(steps);
+    }
+
+    protected void printTestResults(TestResults result) {
+        String res = result.getSteps() > 0 ? (result.isNew() ? "New" : (result.isPassed() ? "Passed" : "Failed")) : "Empty";
+        System.out.printf("\t[%s] - %s", res, name());
+        if (!result.isPassed() && !result.isNew())
+            System.out.printf("\tResult url: %s", result.getUrl());
+        System.out.println();
+
+    }
+
+    public void setEyesUtilitiesConfig(EyesUtilitiesConfig eyesUtilitiesConfig) {
+        eyesUtilitiesConfig_ = eyesUtilitiesConfig;
+    }
+
+    protected static List<Integer> parsePagesToList(String input) {
+        if (input == null) return null;
+        ArrayList<Integer> pagesToInclude = new ArrayList<Integer>();
+        String[] inputPages = input.split(",");
+        for (int i = 0; i < inputPages.length; i++) {
+            if (inputPages[i].contains("-")) {
+                int left = Integer.valueOf(inputPages[i].split("-")[0]);
+                int right = Integer.valueOf(inputPages[i].split("-")[1]);
+                if (left <= right) {
+                    for (int j = left; j <= right; j++) {
+                        pagesToInclude.add(j);
+                    }
+                } else {
+                    for (int j = left; j >= right; j--) {
+                        pagesToInclude.add(j);
+                    }
+                }
+            } else {
+                pagesToInclude.add(Integer.valueOf(inputPages[i]));
+            }
+        }
+        return pagesToInclude;
+
+    }
+
+    public void dispose() {
+        if (steps_ == null) return;
+        for (ITestable step : steps_) {
+            if (step instanceof IDisposable) ((IDisposable) step).dispose();
+        }
+    }
+}

--- a/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/TestUnit.java
+++ b/Eyes/ImageTester/src/lib/java/com/applitools/ImageTester/TestObjects/TestUnit.java
@@ -1,0 +1,32 @@
+package com.applitools.ImageTester.TestObjects;
+
+import com.applitools.ImageTester.Interfaces.IDisposable;
+import com.applitools.ImageTester.Interfaces.ITestable;
+
+import java.io.File;
+
+public abstract class TestUnit implements ITestable, IDisposable {
+    protected final File file_;
+    protected String name_;
+
+    protected TestUnit(File file) {
+        file_ = file;
+        if (file != null && !file.canRead()) {
+            throw new RuntimeException(String.format("Unreadable path/file %s, might be a permission issue!", file.getAbsolutePath()));
+        }
+    }
+
+    protected TestUnit(String name) {
+        file_ = null;
+        name_ = name;
+    }
+
+    public String name() {
+        return file_ == null ? name_ : file_.getName();
+    }
+
+    public File getFile() {
+        return file_;
+    }
+
+}

--- a/Eyes/ImageTester/src/main/java/META-INF/MANIFEST.MF
+++ b/Eyes/ImageTester/src/main/java/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: com.applitools.ImageTester.ImageTester
+Class-Path: ./EyesUtilities.jar

--- a/Eyes/ImageTester/src/main/java/com/applitools/ImageTester/ImageTester.java
+++ b/Eyes/ImageTester/src/main/java/com/applitools/ImageTester/ImageTester.java
@@ -1,0 +1,287 @@
+package com.applitools.ImageTester;
+
+import com.applitools.ImageTester.Interfaces.ITestable;
+import com.applitools.eyes.*;
+import com.applitools.eyes.images.Eyes;
+import org.apache.commons.cli.*;
+import org.apache.log4j.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class ImageTester {
+    private static final String cur_ver = "0.2.7"; //TODO find more suitable place and logic
+    private static final String eyes_utils = "EyesUtilities.jar";
+
+    private static boolean eyes_utils_enabled = false;
+
+    public static void main(String[] args) {
+        PrintStream out = System.out;
+        eyes_utils_enabled = new File(eyes_utils).exists();
+        CommandLineParser parser = new DefaultParser();
+        Options options = getOptions();
+
+        // This part disables log4j warnings
+        org.apache.log4j.Logger.getRootLogger().setLevel(Level.OFF);
+
+        try {
+            CommandLine cmd = parser.parse(options, args);
+            Eyes eyes = new Eyes() {
+                @Override
+                public String getBaseAgentId() {
+                    return String.format("ImageTester/%s [%s]", cur_ver, super.getBaseAgentId());
+                }
+            };
+
+            //API key
+            eyes.setApiKey(cmd.getOptionValue("k"));
+            // Applitools Server url
+            if (cmd.hasOption("s")) eyes.setServerUrl(new URI(cmd.getOptionValue("s")));
+            // Match level
+            if (cmd.hasOption("ml")) eyes.setMatchLevel(Utils.parseEnum(MatchLevel.class, cmd.getOptionValue("ml")));
+            // Proxy
+            if (cmd.hasOption("p")) {
+                String[] proxyops = cmd.getOptionValues("p");
+                if (proxyops.length == 1)
+                    eyes.setProxy(new ProxySettings(proxyops[0]));
+                else if (proxyops.length == 3) {
+                    eyes.setProxy(new ProxySettings(proxyops[0], proxyops[1], proxyops[2]));
+                } else
+                    throw new ParseException("Proxy setting are invalid");
+            }
+
+            // Branch name
+            if (cmd.hasOption("br")) eyes.setBranchName(cmd.getOptionValue("br"));
+            // Parent branch
+            if (cmd.hasOption("pb")) eyes.setParentBranchName(cmd.getOptionValue("pb"));
+            // Baseline name
+            if (cmd.hasOption("bn")) eyes.setBaselineEnvName(cmd.getOptionValue("bn"));
+            // Parent branch
+            if (cmd.hasOption("pb") && !cmd.hasOption("br"))
+                throw new ParseException("Parent Branches (pb) should be combined with branches (br).");
+            // Log file
+            if (cmd.hasOption("lf")) eyes.setLogHandler(new FileLogger(cmd.getOptionValue("lf"), true, true));
+            //host os
+            if (cmd.hasOption("os")) eyes.setHostOS(cmd.getOptionValue("os"));
+            //host app
+            if (cmd.hasOption("ap")) eyes.setHostApp(cmd.getOptionValue("ap"));
+            // Set failed tests
+            eyes.setSaveFailedTests(cmd.hasOption("as"));
+            // Viewport size
+            RectangleSize viewport = null;
+            if (cmd.hasOption("vs")) {
+                String[] dims = cmd.getOptionValue("vs").split("x");
+                if (dims.length != 2)
+                    throw new ParseException("invalid viewport-size, make sure the call is -vs <width>x<height>");
+                viewport = new RectangleSize(Integer.parseInt(dims[0]), Integer.parseInt(dims[1]));
+            }
+            // Folder path
+            File root = new File(cmd.getOptionValue("f", "."));
+            root = new File(root.getCanonicalPath());
+
+            SuiteBuilder builder = new SuiteBuilder(root, cmd.getOptionValue("a", "ImageTester"), viewport);
+
+            //DPI
+            builder.setDpi(Float.valueOf(cmd.getOptionValue("dpi", "300")));
+
+            // Determine Pages to include
+            if (cmd.hasOption("sp")) builder.setPages(cmd.getOptionValue("sp"));
+
+            // Read PDF Password
+            if (cmd.hasOption("pp")) builder.setPdfPassword(cmd.getOptionValue("pp"));
+
+
+
+            if (eyes_utils_enabled) builder.setEyesUtilitiesConfig(new EyesUtilitiesConfig(cmd));
+
+
+            ITestable suite = builder.build();
+            if (suite == null) {
+                System.out.printf("Nothing to test!\n");
+                System.exit(0);
+            }
+
+            suite.run(eyes);
+        } catch (ParseException e) {
+            out.println(e.getMessage());
+            HelpFormatter formatter = new HelpFormatter();
+            formatter.printHelp("ImageTester -k <api-key> [options]", options);
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+            System.exit(-1);
+        } catch (IOException e) {
+            e.printStackTrace();
+            System.exit(-1);
+        }
+    }
+
+    private static Options getOptions() {
+        Options options = new Options();
+
+        options.addOption(Option.builder("k")
+                .longOpt("apiKey")
+                .desc("Applitools api key")
+                .required()
+                .hasArg().argName("apikey")
+                .build());
+
+        options.addOption(Option.builder("a")
+                .longOpt("AppName")
+                .desc("Set own application name, default: ImageTester")
+                .hasArg()
+                .argName("name")
+                .build()
+        );
+
+        options.addOption(Option.builder("f")
+                .longOpt("folder")
+                .desc("Set the root folder to start the analysis, default: \\.")
+                .hasArg()
+                .argName("path")
+                .build()
+        );
+
+        options.addOption(Option.builder("p")
+                .longOpt("proxy")
+                .desc("Set proxy address")
+                .numberOfArgs(3)
+                .optionalArg(true)
+                .valueSeparator(';') //; and not : to avoid split of the http: part.
+                .argName("url [;user;password]")
+                .build()
+        );
+
+        options.addOption(Option.builder("s")
+                .longOpt("server")
+                .desc("Set Applitools server url")
+                .hasArg()
+                .argName("url")
+                .build()
+        );
+
+        options.addOption(Option.builder("ml")
+                .longOpt("matchLevel")
+                .desc(String.format("Set match level to one of [%s], default = Strict", Utils.getEnumValues(MatchLevels.class)))
+                .hasArg()
+                .argName("level")
+                .build());
+
+        options.addOption(Option.builder("br")
+                .longOpt("branch")
+                .desc("Set branch name")
+                .hasArg()
+                .argName("name")
+                .build());
+
+        options.addOption(Option.builder("pb")
+                .longOpt("parentBranch")
+                .desc("Set parent branch name, optional when working with branches")
+                .hasArg()
+                .argName("name")
+                .build());
+
+        options.addOption(Option.builder("bn")
+                .longOpt("baseline")
+                .desc("Set baseline name")
+                .hasArg()
+                .argName("name")
+                .build());
+
+        options.addOption(Option.builder("vs")
+                .longOpt("viewportsize")
+                .desc("Declare viewport size identifier <width>x<height> ie. 1000x600, if not set,default will be the first image in every test")
+                .hasArg()
+                .argName("size")
+                .build());
+
+        options.addOption(Option.builder("lf")
+                .longOpt("logFile")
+                .desc("Specify Applitools log-file")
+                .hasArg()
+                .argName("file")
+                .build());
+
+        options.addOption(Option.builder("as")
+                .longOpt("autoSave")
+                .desc("Automatically save failed tests. Waring, might save buggy baselines without human inspection. ")
+                .hasArg(false)
+                .build());
+
+        options.addOption(Option.builder("os")
+                .longOpt("hostOs")
+                .desc("Set OS identifier for the screens under test")
+                .hasArg()
+                .argName("os")
+                .build());
+
+        options.addOption(Option.builder("ap")
+                .longOpt("hostApp")
+                .desc("Set Host-app identifier for the screens under test")
+                .hasArg()
+                .argName("app")
+                .build());
+        options.addOption(Option.builder("di")
+                .longOpt("dpi")
+                .desc("PDF conversion dots per inch parameter default value 300")
+                .hasArg()
+                .argName("Dpi")
+                .build());
+        options.addOption(Option.builder("sp")
+                .longOpt("selectedPages")
+                .desc("PDF pages to select")
+                .hasArg()
+                .argName("Pages")
+                .build());
+        options.addOption(Option.builder("pp")
+                .longOpt("PDFPassword")
+                .desc("PDF Password")
+                .hasArg()
+                .argName("Password")
+                .build());
+
+
+        if (eyes_utils_enabled) {
+            System.out.printf("%s is integrated, extra features are available. \n", eyes_utils);
+            options.addOption(Option.builder("vk")
+                    .longOpt("viewKey")
+                    .desc("Specify enterprise view-key for additional api functions")
+                    .hasArg()
+                    .argName("key")
+                    .build()
+            );
+
+            options.addOption(Option.builder("of")
+                    .longOpt("outFolder")
+                    .hasArg()
+                    .desc("Specify the output target folder for the images results")
+                    .argName("folder")
+                    .build()
+            );
+
+            options.addOption(Option.builder("gd")
+                    .longOpt("getDiffs")
+                    .desc("Download diffs")
+                    .hasArg(false)
+                    .build()
+            );
+
+            options.addOption(Option.builder("gi")
+                    .longOpt("getImages")
+                    .desc("Download baseline and actual images")
+                    .hasArg(false)
+                    .build()
+            );
+
+            options.addOption(Option.builder("gg")
+                    .longOpt("getGifs")
+                    .desc("Download animated gif of the results")
+                    .hasArg(false)
+                    .build()
+            );
+        }
+        return options;
+    }
+}

--- a/Eyes/ImageTester/src/main/java/com/applitools/ImageTester/Utils.java
+++ b/Eyes/ImageTester/src/main/java/com/applitools/ImageTester/Utils.java
@@ -1,0 +1,29 @@
+package com.applitools.ImageTester;
+
+import com.sun.xml.internal.ws.util.StringUtils;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.ParseException;
+
+import java.util.EnumSet;
+
+public class Utils {
+
+    public static <T extends Enum<T>> T parseEnum(Class<T> c, String string) throws ParseException {
+        if (c != null && string != null) {
+            try {
+                return Enum.valueOf(c, string.trim().toUpperCase());
+            } catch (IllegalArgumentException ex) {
+            }
+        }
+        throw new ParseException(String.format("Unable to parse value %s for enum %s", string, c.getName()));
+    }
+
+    public static String getEnumValues(Class type) {
+        StringBuilder sb = new StringBuilder();
+        for (Object val : EnumSet.allOf(type)) {
+            sb.append(StringUtils.capitalize(val.toString().toLowerCase()));
+            sb.append('|');
+        }
+        return sb.substring(0, sb.length() - 1);
+    }
+}

--- a/Eyes/ImageTester/src/main/resources/META-INF/MANIFEST.MF
+++ b/Eyes/ImageTester/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: com.applitools.ImageTester.ImageTester
+Class-Path: ./EyesUtilities.jar

--- a/Eyes/Ranorex.Eyes.nuspec
+++ b/Eyes/Ranorex.Eyes.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Ranorex.Eyes</id>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
         <title>Ranorex with Applitools Eyes</title>
         <authors>Ranorex GmbH</authors>
         <owners>Ranorex GmbH</owners>

--- a/Eyes/src/Modules/EyesWrapper.cs
+++ b/Eyes/src/Modules/EyesWrapper.cs
@@ -86,27 +86,33 @@ namespace Ranorex.Eyes
             suite.Run(eyes);
         }
 
+        [Obsolete("Parameter throwException is no longer used, please use CloseTest() instead.", false)]
         public static void CloseTest(bool throwException)
+        {
+            CloseTest();
+        }
+
+        public static void CloseTest()
         {
             if (testRunning)
             {
-                try
+                var results = eyes.Close(throwEx: false);
+
+                if(results.IsNew)
                 {
-                    eyes.Close(throwException);
+                    Report.LogHtml(ReportLevel.Warn, "Visual Testing", string.Format("New baseline created; please approve here: <a href='{0}'>Applitools backend</a>", results.Url));
                 }
-                catch (NewTestException e)
+                if(results.IsPassed)
                 {
-                    Report.LogHtml(ReportLevel.Warn, "Visual Testing", string.Format("New baseline created; please approve here: <a href='{0}'>Applitools backend</a>", e.TestResults.Url));
+                    Report.LogHtml(ReportLevel.Info, "Visual Testing", string.Format("Visual test passed; check results here: <a href='{0}'>Applitools backend</a>", results.Url));
                 }
-                catch (TestFailedException e)
+                else
                 {
-                    Report.LogHtml(ReportLevel.Failure, "Visual Testing", string.Format("Visual test failed; please check results here: <a href='{0}'>Applitools backend</a>", e.TestResults.Url));
+                    Report.LogHtml(ReportLevel.Failure, "Visual Testing", string.Format("Visual test failed; please check results here: <a href='{0}'>Applitools backend</a>", results.Url));
                 }
-                finally
-                {
-                    testRunning = false;
-                    eyes.AbortIfNotClosed();
-                }
+
+                testRunning = false;
+                eyes.AbortIfNotClosed();
             }
         }
 
@@ -122,7 +128,7 @@ namespace Ranorex.Eyes
             {
                 if (!testName.Equals(currentTestName))
                 {
-                    CloseTest(true);
+                    CloseTest();
                     StartOrContinueTest(testName);
                 }
             }

--- a/Eyes/src/Modules/EyesWrapper.cs
+++ b/Eyes/src/Modules/EyesWrapper.cs
@@ -83,7 +83,6 @@ namespace Ranorex.Eyes
             }
 
             Report.Info("Visual Checkpoint - file comparison (PDF/Images).");
-
             suite.Run(eyes);
         }
 
@@ -106,6 +105,7 @@ namespace Ranorex.Eyes
                 finally
                 {
                     testRunning = false;
+                    eyes.AbortIfNotClosed();
                 }
             }
         }

--- a/Eyes/src/Modules/FinalizeEyes.cs
+++ b/Eyes/src/Modules/FinalizeEyes.cs
@@ -22,7 +22,7 @@ namespace Ranorex.Eyes
         void ITestModule.Run()
         {
             Report.Info("Applitools: Closing Eyes.");
-            EyesWrapper.CloseTest(true);
+            EyesWrapper.CloseTest();
         }
     }
 }

--- a/Eyes/src/UserCodeCollections/EyesLibrary.cs
+++ b/Eyes/src/UserCodeCollections/EyesLibrary.cs
@@ -84,6 +84,7 @@ namespace Ranorex.Eyes
                 fileOrFolderPath = System.IO.Directory.GetCurrentDirectory() + @"\" + fileOrFolderPath;
             }
 
+            EyesWrapper.StartOrContinueTest(GetTestCaseName());
             EyesWrapper.CheckFolder(fileOrFolderPath);
         }
 
@@ -110,13 +111,7 @@ namespace Ranorex.Eyes
         		throw new ArgumentNullException("adapter");
         	}
 
-            var testCaseName = string.Empty;
-            if (TestSuite.Current != null)
-            {
-                testCaseName = TestSuite.Current.CurrentTestContainer.Name;
-            }
-
-            EyesWrapper.StartOrContinueTest(testCaseName);
+            EyesWrapper.StartOrContinueTest(GetTestCaseName());
             Report.Info(string.Format("Applitools 'CheckImage' called with screenshot from repository item '{0}'.", adapter));
 
             try
@@ -160,6 +155,16 @@ namespace Ranorex.Eyes
             {
                 ProgressForm.SetOpacity(100);
             }
+        }
+
+        private static string GetTestCaseName()
+        {
+            var testCaseName = string.Empty;
+            if (TestSuite.Current != null)
+            {
+                testCaseName = TestSuite.Current.CurrentTestContainer.Name;
+            }
+            return testCaseName;
         }
     }
 }


### PR DESCRIPTION
Work Item: 30199 Ranorex does not register a failure when applitools
eyes PDF validation fails

Issue is caused by the fact that approach for checking PDF and
directories was not unified with other types of visual checkpoints and
Eyes close method is called prematurely. Recommended workflow (from
AppliTools docs) is that close method is called at the end of the test,
in our case in the finalize method which should be placed in the
Teardown section. 

ImageTester library un-submoduled and added to the project normally as
per the internal discussion from earlier. Needs manual testing to make 
sure that everything is pulled correctly from nuget when merged to 
master?