### PR TITLE
Eyes: Remove outdated ProgressForm calls

### DIFF
--- a/Eyes/Ranorex.Eyes.nuspec
+++ b/Eyes/Ranorex.Eyes.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Ranorex.Eyes</id>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <title>Ranorex with Applitools Eyes</title>
         <authors>Ranorex GmbH</authors>
         <owners>Ranorex GmbH</owners>

--- a/Eyes/src/UserCodeCollections/EyesLibrary.cs
+++ b/Eyes/src/UserCodeCollections/EyesLibrary.cs
@@ -114,47 +114,38 @@ namespace Ranorex.Eyes
             EyesWrapper.StartOrContinueTest(GetTestCaseName());
             Report.Info(string.Format("Applitools 'CheckImage' called with screenshot from repository item '{0}'.", adapter));
 
-            try
+            Bitmap image;
+            if (adapter.Element.HasCapability("webdocument"))
             {
-                ProgressForm.SetOpacity(0);
-
-                Bitmap image;
-                if (adapter.Element.HasCapability("webdocument"))
+                var webDocument = adapter.As<WebDocument>();
+                EyesWrapper.SetBrowserName(webDocument.BrowserName);
+                if (EyesWrapper.ViewPortWidth > 0 && EyesWrapper.ViewPortHeight > 0)
                 {
-                    var webDocument = adapter.As<WebDocument>();
-                    EyesWrapper.SetBrowserName(webDocument.BrowserName);
-                    if (EyesWrapper.ViewPortWidth > 0 && EyesWrapper.ViewPortHeight > 0)
-                    {
-                        webDocument.Browser.Resize(EyesWrapper.ViewPortWidth, EyesWrapper.ViewPortHeight);
-                    }
-
-                    webDocument.WaitForDocumentLoaded();
-                    image = webDocument.CaptureFullPageScreenshot(screenshotCaptureFlag);
-                }
-                else
-                {
-                    var browserName = string.Empty;
-                    if (adapter.Element.HasCapability("webelement"))
-                    {
-                        var parent = adapter.Parent;
-                        while (parent.As<WebDocument>() == null)
-                        {
-                            parent = parent.Parent;
-                        }
-
-                        browserName = parent.As<WebDocument>().BrowserName;
-                    }
-
-                    EyesWrapper.SetBrowserName(browserName);
-                    image = Imaging.CaptureImage(adapter.Element);
+                    webDocument.Browser.Resize(EyesWrapper.ViewPortWidth, EyesWrapper.ViewPortHeight);
                 }
 
-                EyesWrapper.CheckImage(image, stepDescription);
+                webDocument.WaitForDocumentLoaded();
+                image = webDocument.CaptureFullPageScreenshot(screenshotCaptureFlag);
             }
-            finally
+            else
             {
-                ProgressForm.SetOpacity(100);
+                var browserName = string.Empty;
+                if (adapter.Element.HasCapability("webelement"))
+                {
+                    var parent = adapter.Parent;
+                    while (parent.As<WebDocument>() == null)
+                    {
+                        parent = parent.Parent;
+                    }
+
+                    browserName = parent.As<WebDocument>().BrowserName;
+                }
+
+                EyesWrapper.SetBrowserName(browserName);
+                image = Imaging.CaptureImage(adapter.Element);
             }
+
+            EyesWrapper.CheckImage(image, stepDescription);
         }
 
         private static string GetTestCaseName()


### PR DESCRIPTION
ProgressForm usage no longer valid with Ranorex 9.1+ due to a new progress dialog.