### PR TITLE
Helpers: Make logging of the pdf report relative, not absolute

### DIFF
--- a/AutomationHelpers/src/Modules/ReportToPDFModule.cs
+++ b/AutomationHelpers/src/Modules/ReportToPDFModule.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using Ranorex.AutomationHelpers.UserCodeCollections;
 using Ranorex.Core.Reporting;
 using Ranorex.Core.Testing;
 
@@ -155,7 +156,7 @@ namespace Ranorex.AutomationHelpers.Modules
 
 			Ranorex.PDF.Creator.CreatePDF(input, PDFReportFilePath, xml, details);
 
-			return PDFReportFilePath;
+			return Utils.CreateRelativePath(TestReport.ReportEnvironment.ReportDataFilePath, PDFReportFilePath);
 		}
 
 		private static string AddPdfExtension(string pdfName)

--- a/AutomationHelpers/src/Modules/ReportToPDFModule.cs
+++ b/AutomationHelpers/src/Modules/ReportToPDFModule.cs
@@ -156,12 +156,25 @@ namespace Ranorex.AutomationHelpers.Modules
 
 			Ranorex.PDF.Creator.CreatePDF(input, PDFReportFilePath, xml, details);
 
-			return Utils.CreateRelativePath(TestReport.ReportEnvironment.ReportDataFilePath, PDFReportFilePath);
+			return GeneratePathToPdfRelativeToReport(PDFReportFilePath);
 		}
 
 		private static string AddPdfExtension(string pdfName)
 		{
 			return pdfName.EndsWith(".pdf") ? pdfName : pdfName + ".pdf";
+		}
+
+		private static string GeneratePathToPdfRelativeToReport(string currentPdfPath)
+		{
+			var pdfUri = new Uri(currentPdfPath, UriKind.RelativeOrAbsolute);
+			if (!pdfUri.IsAbsoluteUri)
+			{
+				// if the path is relative, its relative to the execution, not report
+				var currentExeUri = new Uri(Environment.CurrentDirectory + "\\");
+				pdfUri = new Uri(currentExeUri, pdfUri);
+			}
+
+			return Utils.CreateRelativePath(TestReport.ReportEnvironment.ReportDataFilePath, pdfUri.AbsoluteUri);
 		}
 
 		private void FinishReport() {

--- a/AutomationHelpers/src/UserCodeCollections/Utils.cs
+++ b/AutomationHelpers/src/UserCodeCollections/Utils.cs
@@ -32,11 +32,17 @@ namespace Ranorex.AutomationHelpers.UserCodeCollections
             CheckArgumentNotNull(source, "source");
             CheckArgumentNotNull(target, "target");
 
-            var sourceUri = new Uri(source);
-            var targetUri = new Uri(target);
+            var sourceUri = new Uri(source, UriKind.Absolute);
+            var targetUri = new Uri(target, UriKind.RelativeOrAbsolute);
 
-            var relative = Uri.UnescapeDataString(sourceUri.MakeRelativeUri(targetUri).ToString());
-            return relative;
+            if (targetUri.IsAbsoluteUri)
+            {
+                return Uri.UnescapeDataString(sourceUri.MakeRelativeUri(targetUri).ToString());
+            }
+            else
+            {
+                return target;
+            }
         }
     }
 }

--- a/AutomationHelpers/src/UserCodeCollections/Utils.cs
+++ b/AutomationHelpers/src/UserCodeCollections/Utils.cs
@@ -26,5 +26,17 @@ namespace Ranorex.AutomationHelpers.UserCodeCollections
                 exception.GetFullMessage(),
                 new SimpleReportMetadata("stacktrace", exception.StackTrace));
         }
+
+        public static string CreateRelativePath(string source, string target)
+        {
+            CheckArgumentNotNull(source, "source");
+            CheckArgumentNotNull(target, "target");
+
+            var sourceUri = new Uri(source);
+            var targetUri = new Uri(target);
+
+            var relative = Uri.UnescapeDataString(sourceUri.MakeRelativeUri(targetUri).ToString());
+            return relative;
+        }
     }
 }


### PR DESCRIPTION
Making the relative path to the generated PDF file will make the usage of the module more robust and allow users to use this module with an agent.