### PR TITLE
Helpers: Fix reseting of binding and pragma warning

### DIFF
--- a/AutomationHelpers/Ranorex.AutomationHelpers.nuspec
+++ b/AutomationHelpers/Ranorex.AutomationHelpers.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Ranorex.AutomationHelpers</id>
-        <version>1.6.1</version>
+        <version>1.6.2</version>
         <title>Ranorex Automation Helpers</title>
         <authors>Ranorex Community</authors>
         <owners>Ranorex GmbH</owners>


### PR DESCRIPTION
Two changes were made in this PR:
1. The delegate was evaluated only one time causing the data binding not to be refreshed, when running multiple test suites
2. The pragma warning is not supporting "CS" prefix for compilers using < C#6. 