### PR TITLE
Helpers: Ensure compatibility to 9.3 using install.ps1

### DIFF
--- a/AutomationHelpers/Ranorex.AutomationHelpers.nuspec
+++ b/AutomationHelpers/Ranorex.AutomationHelpers.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Ranorex.AutomationHelpers</id>
-        <version>1.6.4</version>
+        <version>1.6.5</version>
         <title>Ranorex Automation Helpers</title>
         <authors>Ranorex Community</authors>
         <owners>Ranorex GmbH</owners>

--- a/AutomationHelpers/scripts/install.ps1
+++ b/AutomationHelpers/scripts/install.ps1
@@ -4,6 +4,12 @@ param($installPath, $toolsPath, $package, $project)
 
 Write-Host 'Started adding constant for current Ranorex version to compilation symbols...'
 
+if ($project.Name -ne 'Ranorex Automation Helpers')
+{
+    Write-Information('Ignore the non-helper project ' + $project.Name)
+    exit
+}
+
 $rxVersion = GET-VARIABLE RanorexVersion -ErrorAction 'Ignore'
 $rxVersion = $rxVersion.Value -replace '\.'
 if (!$rxVersion)

--- a/AutomationHelpers/scripts/install.ps1
+++ b/AutomationHelpers/scripts/install.ps1
@@ -4,7 +4,7 @@ param($installPath, $toolsPath, $package, $project)
 
 Write-Host 'Started adding constant for current Ranorex version to compilation symbols...'
 
-$rxVersion = $project.Properties.Item("RanorexVersion")
+$rxVersion = GET-VARIABLE RanorexVersion
 $rxVersion = $rxVersion.Value -replace '\.'
 if (!$rxVersion)
 {

--- a/AutomationHelpers/scripts/install.ps1
+++ b/AutomationHelpers/scripts/install.ps1
@@ -1,4 +1,4 @@
-# Copyright © 2018 Ranorex All rights reserved
+# Copyright Â© 2018 Ranorex All rights reserved
 
 param($installPath, $toolsPath, $package, $project)
 
@@ -12,7 +12,7 @@ if (!$rxVersion)
     exit
 }
 $rxVersion = "RX$rxVersion"
-if ($rxVersion -ne "RX72" -and $rxVersion -ne "RX80")
+if ($rxVersion -ne "RX72" -and $rxVersion -ne "RX80" -and $rxVersion -ne "RX93")
 {
     Write-Warning('Current Ranorex version is fully supported by this package.')
     exit

--- a/AutomationHelpers/scripts/install.ps1
+++ b/AutomationHelpers/scripts/install.ps1
@@ -12,11 +12,6 @@ if (!$rxVersion)
     exit
 }
 $rxVersion = "RX$rxVersion"
-if ($rxVersion -ne "RX72" -and $rxVersion -ne "RX80" -and $rxVersion -ne "RX93")
-{
-    Write-Warning('Current Ranorex version is fully supported by this package.')
-    exit
-}
 
 $defineConstants = $project.Properties.Item("DefineConstants")
 [array]$symbols = $defineConstants.Value.Split(';')

--- a/AutomationHelpers/scripts/install.ps1
+++ b/AutomationHelpers/scripts/install.ps1
@@ -4,11 +4,11 @@ param($installPath, $toolsPath, $package, $project)
 
 Write-Host 'Started adding constant for current Ranorex version to compilation symbols...'
 
-$rxVersion = GET-VARIABLE RanorexVersion
+$rxVersion = GET-VARIABLE RanorexVersion -ErrorAction 'Ignore'
 $rxVersion = $rxVersion.Value -replace '\.'
 if (!$rxVersion)
 {
-    Write-Warning('Could not find Ranorex version property in project.')
+    Write-Warning('Could not find Ranorex version variable.')
     exit
 }
 $rxVersion = "RX$rxVersion"

--- a/AutomationHelpers/scripts/uninstall.ps1
+++ b/AutomationHelpers/scripts/uninstall.ps1
@@ -4,6 +4,12 @@ param($installPath, $toolsPath, $package, $project)
 
 Write-Host 'Started removing constant for current Ranorex version from compilation symbols...'
 
+if ($project.Name -ne 'Ranorex Automation Helpers')
+{
+    Write-Information('Ignore the non-helper project ' + $project.Name)
+    exit
+}
+
 $rxVersion = GET-VARIABLE RanorexVersion -ErrorAction 'Ignore'
 $rxVersion = $rxVersion.Value -replace '\.'
 if (!$rxVersion)

--- a/AutomationHelpers/scripts/uninstall.ps1
+++ b/AutomationHelpers/scripts/uninstall.ps1
@@ -4,11 +4,11 @@ param($installPath, $toolsPath, $package, $project)
 
 Write-Host 'Started removing constant for current Ranorex version from compilation symbols...'
 
-$rxVersion = GET-VARIABLE RanorexVersion
+$rxVersion = GET-VARIABLE RanorexVersion -ErrorAction 'Ignore'
 $rxVersion = $rxVersion.Value -replace '\.'
 if (!$rxVersion)
 {
-    Write-Information('Could not find Ranorex version property, ignore removing constant for this project.')
+    Write-Information('Could not find Ranorex version variable, ignore removing constant for this project.')
     exit
 }
 

--- a/AutomationHelpers/scripts/uninstall.ps1
+++ b/AutomationHelpers/scripts/uninstall.ps1
@@ -1,10 +1,10 @@
-# Copyright © 2018 Ranorex All rights reserved
+# Copyright Â© 2018 Ranorex All rights reserved
 
 param($installPath, $toolsPath, $package, $project)
 
 Write-Host 'Started removing constant for current Ranorex version from compilation symbols...'
 
-$rxVersion = $project.Properties.Item("RanorexVersion")
+$rxVersion = GET-VARIABLE RanorexVersion
 $rxVersion = $rxVersion.Value -replace '\.'
 if (!$rxVersion)
 {


### PR DESCRIPTION
Fix to add RanorexVersion property for Ranorex Automation Helper
The install script uses the RanorexVersion and adds it to symbols

Related WorkItem: 32770