### PR TITLE
Update Applitools packages to newer versions

### DIFF
--- a/Eyes/ImageTester/src/csharp/lib/Applitools.ImageTester.csproj
+++ b/Eyes/ImageTester/src/csharp/lib/Applitools.ImageTester.csproj
@@ -34,17 +34,36 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Eyes.Bundle, Version=1.22.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\bin\Release\Eyes.Bundle.dll</HintPath>
+    <Reference Include="AutoMapper, Version=7.0.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.7.0.1\lib\net45\AutoMapper.dll</HintPath>
+    </Reference>
+    <Reference Include="Eyes.Image.Core.DotNet, Version=4.16.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eyes.Image.Core.4.16.1\lib\net45\Eyes.Image.Core.DotNet.dll</HintPath>
+    </Reference>
+    <Reference Include="Eyes.Images.DotNet, Version=3.52.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eyes.Images.3.52.0\lib\net45\Eyes.Images.DotNet.dll</HintPath>
+    </Reference>
+    <Reference Include="log4net, Version=1.2.11.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.0\lib\net40-full\log4net.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PdfiumViewer, Version=2.12.0.0, Culture=neutral, PublicKeyToken=91e4789cfb0609e0, processorArchitecture=MSIL">
       <HintPath>..\packages\PdfiumViewer.2.12.0.0\lib\net20\PdfiumViewer.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -73,26 +92,34 @@
     <Content Include="x86\pdfium.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets" Condition="Exists('..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets')" />
+  <Import Project="..\packages\ILRepack.Lib.MSBuild.Task.2.0.34\build\ILRepack.Lib.MSBuild.Task.targets" Condition="Exists('..\packages\ILRepack.Lib.MSBuild.Task.2.0.34\build\ILRepack.Lib.MSBuild.Task.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets'))" />
     <Error Condition="!Exists('..\packages\PdfiumViewer.Native.x86.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86.v8-xfa.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PdfiumViewer.Native.x86.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86.v8-xfa.props'))" />
     <Error Condition="!Exists('..\packages\PdfiumViewer.Native.x86_64.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86_64.v8-xfa.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PdfiumViewer.Native.x86_64.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86_64.v8-xfa.props'))" />
+    <Error Condition="!Exists('..\packages\ILRepack.Lib.MSBuild.Task.2.0.34\build\ILRepack.Lib.MSBuild.Task.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILRepack.Lib.MSBuild.Task.2.0.34\build\ILRepack.Lib.MSBuild.Task.targets'))" />
   </Target>
   <!-- ILRepack -->
-  <Target Name="BeforeBuild">
+  <Target Name="ILRepacker" AfterTargets="Build">
     <ItemGroup>
-      <InputAssemblies Include="..\packages\Eyes.Images.1.22.0\lib\net35\Eyes.Images.dll" />
-      <InputAssemblies Include="..\packages\Eyes.Sdk.2.5.3\lib\net45\Eyes.Sdk.DotNet.dll" />
-      <InputAssemblies Include="..\packages\Eyes.Sdk.2.5.3\lib\net45\Eyes.Utils.DotNet.dll" />
-      <InputAssemblies Include="..\packages\DotNetZip.Reduced.1.9.1.8\lib\net20\Ionic.Zip.Reduced.dll" />
-      <InputAssemblies Include="..\packages\log4net.2.0.0\lib\net40-full\log4net.dll" />
-      <InputAssemblies Include="..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll" />
+	  <InputAssemblies Include="$(TargetPath)" />
+      <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'Newtonsoft.Json'" />
+      <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'Eyes.Images.DotNet'" />
+      <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'Eyes.Image.Core.DotNet'" />
+      <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'Ionic.Zip.Reduced'" />
+      <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'log4net'" />
+      <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'AutoMapper'" />
+	  <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'PdfiumViewer'" />
+      <!--<InputAssemblies Include="..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll" />
+        <InputAssemblies Include="..\packages\Eyes.Images.3.52.0\lib\net45\Eyes.Images.DotNet.dll" />
+        <InputAssemblies Include="..\packages\Eyes.Image.Core.4.16.1\lib\net45\Eyes.Image.Core.DotNet.dll" />
+        <InputAssemblies Include="..\packages\DotNetZip.Reduced.1.9.1.8\lib\net20\Ionic.Zip.Reduced.dll" />
+        <InputAssemblies Include="..\packages\log4net.2.0.0\lib\net40-full\log4net.dll" />
+        <InputAssemblies Include="..\packages\AutoMapper.10.1.1\lib\net461\AutoMapper.dll" />-->
     </ItemGroup>
-    <ILRepack InputAssemblies="@(InputAssemblies)" TargetKind="Dll" OutputFile="$(OutputPath)\Eyes.Bundle.dll" />
+    <ILRepack AllowDuplicateResources="false" DebugInfo="true" InputAssemblies="@(InputAssemblies)" OutputFile=".\bin\$(Configuration)\Eyes.Bundle.dll" Parallel="true" TargetKind="SameAsPrimaryAssembly" />
   </Target>
   <!-- /ILRepack -->
 </Project>

--- a/Eyes/ImageTester/src/csharp/lib/Applitools.ImageTester.csproj
+++ b/Eyes/ImageTester/src/csharp/lib/Applitools.ImageTester.csproj
@@ -92,28 +92,32 @@
     <Content Include="x86\pdfium.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\ILRepack.Lib.MSBuild.Task.2.0.34\build\ILRepack.Lib.MSBuild.Task.targets" Condition="Exists('..\packages\ILRepack.Lib.MSBuild.Task.2.0.34\build\ILRepack.Lib.MSBuild.Task.targets')" />
+  <Import Project="..\packages\ILRepack.Lib.MSBuild.Task.2.0.34.1\build\ILRepack.LIb.MSBuild.Task.targets" Condition="Exists('..\packages\ILRepack.Lib.MSBuild.Task.2.0.34.1\build\ILRepack.LIb.MSBuild.Task.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
+    <Error Condition="!Exists('..\packages\ILRepack.Lib.MSBuild.Task.2.0.34.1\build\ILRepack.LIb.MSBuild.Task.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILRepack.Lib.MSBuild.Task.2.0.34.1\build\ILRepack.LIb.MSBuild.Task.targets'))" />
     <Error Condition="!Exists('..\packages\PdfiumViewer.Native.x86.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86.v8-xfa.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PdfiumViewer.Native.x86.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86.v8-xfa.props'))" />
     <Error Condition="!Exists('..\packages\PdfiumViewer.Native.x86_64.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86_64.v8-xfa.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PdfiumViewer.Native.x86_64.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86_64.v8-xfa.props'))" />
-    <Error Condition="!Exists('..\packages\ILRepack.Lib.MSBuild.Task.2.0.34\build\ILRepack.Lib.MSBuild.Task.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILRepack.Lib.MSBuild.Task.2.0.34\build\ILRepack.Lib.MSBuild.Task.targets'))" />
   </Target>
   <!-- ILRepack -->
-  <Target Name="ILRepacker" AfterTargets="Build">
+  <Target Name="ILRepacker" BeforeTargets="Build">
     <ItemGroup>
-	  <InputAssemblies Include="$(TargetPath)" />
+      <InputAssemblies Include="$(TargetPath)" />
       <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'Newtonsoft.Json'" />
       <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'Eyes.Images.DotNet'" />
       <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'Eyes.Image.Core.DotNet'" />
+	  <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'System.Net.Http'" />
+	  <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'System.Runtime'" />
+	  <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'System.Runtime.InteropServices.RuntimeInformation'" />
+	  <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'System.ValueTuple'" />
       <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'Ionic.Zip.Reduced'" />
       <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'log4net'" />
       <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'AutoMapper'" />
-	  <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'PdfiumViewer'" />
+      <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'PdfiumViewer'" />
     </ItemGroup>
-    <ILRepack AllowDuplicateResources="false" DebugInfo="true" InputAssemblies="@(InputAssemblies)" OutputFile=".\bin\$(Configuration)\Eyes.Bundle.dll" Parallel="true" TargetKind="SameAsPrimaryAssembly" />
+    <ILRepack Parallel="true" InputAssemblies="@(InputAssemblies)" TargetKind="Dll" OutputFile="$(OutputPath)Eyes.Bundle.dll" />
   </Target>
   <!-- /ILRepack -->
 </Project>

--- a/Eyes/ImageTester/src/csharp/lib/Applitools.ImageTester.csproj
+++ b/Eyes/ImageTester/src/csharp/lib/Applitools.ImageTester.csproj
@@ -112,12 +112,6 @@
       <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'log4net'" />
       <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'AutoMapper'" />
 	  <InputAssemblies Include="@(ReferencePathWithRefAssemblies)" Condition="'%(filename)' == 'PdfiumViewer'" />
-      <!--<InputAssemblies Include="..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll" />
-        <InputAssemblies Include="..\packages\Eyes.Images.3.52.0\lib\net45\Eyes.Images.DotNet.dll" />
-        <InputAssemblies Include="..\packages\Eyes.Image.Core.4.16.1\lib\net45\Eyes.Image.Core.DotNet.dll" />
-        <InputAssemblies Include="..\packages\DotNetZip.Reduced.1.9.1.8\lib\net20\Ionic.Zip.Reduced.dll" />
-        <InputAssemblies Include="..\packages\log4net.2.0.0\lib\net40-full\log4net.dll" />
-        <InputAssemblies Include="..\packages\AutoMapper.10.1.1\lib\net461\AutoMapper.dll" />-->
     </ItemGroup>
     <ILRepack AllowDuplicateResources="false" DebugInfo="true" InputAssemblies="@(InputAssemblies)" OutputFile=".\bin\$(Configuration)\Eyes.Bundle.dll" Parallel="true" TargetKind="SameAsPrimaryAssembly" />
   </Target>

--- a/Eyes/ImageTester/src/csharp/lib/Properties/AssemblyInfo.cs
+++ b/Eyes/ImageTester/src/csharp/lib/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/Eyes/ImageTester/src/csharp/lib/Ranorex.Eyes.props
+++ b/Eyes/ImageTester/src/csharp/lib/Ranorex.Eyes.props
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)runtimes\win-x64\native\core-win.exe">
+	  <Link>runtimes\win-x64\native\core-win.exe</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/Eyes/ImageTester/src/csharp/lib/app.config
+++ b/Eyes/ImageTester/src/csharp/lib/app.config
@@ -1,11 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+	<startup>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+	</startup>
   <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
+	  <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+		  <dependentAssembly>
+			  <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+			  <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+		  </dependentAssembly>
+	  </assemblyBinding>
   </runtime>
 </configuration>

--- a/Eyes/ImageTester/src/csharp/lib/packages.config
+++ b/Eyes/ImageTester/src/csharp/lib/packages.config
@@ -1,12 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AutoMapper" version="7.0.1" targetFramework="net452" />
   <package id="DotNetZip.Reduced" version="1.9.1.8" targetFramework="net452" />
-  <package id="Eyes.Images" version="1.22.0" targetFramework="net452" />
-  <package id="Eyes.Sdk" version="2.5.3" targetFramework="net452" />
-  <package id="ILRepack.MSBuild.Task" version="1.0.9" targetFramework="net452" />
+  <package id="Eyes.Image.Core" version="4.16.1" targetFramework="net452" />
+  <package id="Eyes.Images" version="3.52.0" targetFramework="net452" />
+  <package id="ILRepack.Lib.MSBuild.Task" version="2.0.34" targetFramework="net452" developmentDependency="true" />
   <package id="log4net" version="2.0.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net452" />
   <package id="PdfiumViewer" version="2.12.0.0" targetFramework="net452" />
   <package id="PdfiumViewer.Native.x86.v8-xfa" version="2018.4.8.256" targetFramework="net452" />
   <package id="PdfiumViewer.Native.x86_64.v8-xfa" version="2018.4.8.256" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net452" />
+  <package id="System.Runtime" version="4.3.1" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
 </packages>

--- a/Eyes/ImageTester/src/csharp/lib/packages.config
+++ b/Eyes/ImageTester/src/csharp/lib/packages.config
@@ -4,7 +4,7 @@
   <package id="DotNetZip.Reduced" version="1.9.1.8" targetFramework="net452" />
   <package id="Eyes.Image.Core" version="4.16.1" targetFramework="net452" />
   <package id="Eyes.Images" version="3.52.0" targetFramework="net452" />
-  <package id="ILRepack.Lib.MSBuild.Task" version="2.0.34" targetFramework="net452" developmentDependency="true" />
+  <package id="ILRepack.Lib.MSBuild.Task" version="2.0.34.1" targetFramework="net452" developmentDependency="true" />
   <package id="log4net" version="2.0.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net452" />
   <package id="PdfiumViewer" version="2.12.0.0" targetFramework="net452" />

--- a/Eyes/ImageTester/src/csharp/main/App.config
+++ b/Eyes/ImageTester/src/csharp/main/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.9.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Eyes/ImageTester/src/csharp/main/Applitools.ImageTester.Runner.csproj
+++ b/Eyes/ImageTester/src/csharp/main/Applitools.ImageTester.Runner.csproj
@@ -35,7 +35,7 @@
     <Reference Include="CommandLine, Version=2.2.1.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
       <HintPath>..\packages\CommandLineParser.2.2.1\lib\net45\CommandLine.dll</HintPath>
     </Reference>
-    <Reference Include="Eyes.Bundle, Version=1.22.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Eyes.Bundle, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\bin\Release\Eyes.Bundle.dll</HintPath>
     </Reference>
@@ -56,12 +56,6 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\lib\Applitools.ImageTester.csproj">
-      <Project>{CD3852A3-83F4-42D2-A109-9D3DA663691A}</Project>
-      <Name>Applitools.ImageTester</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Eyes/ImageTester/src/csharp/main/packages.config
+++ b/Eyes/ImageTester/src/csharp/main/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AutoMapper" version="10.1.1" targetFramework="net452" />
   <package id="CommandLineParser" version="2.2.1" targetFramework="net452" />
   <package id="DotNetZip.Reduced" version="1.9.1.8" targetFramework="net452" />
-  <package id="Eyes.Images" version="1.22.0" targetFramework="net452" />
-  <package id="Eyes.Sdk" version="2.5.3" targetFramework="net452" />
+  <package id="Eyes.Image.Core" version="4.16.1" targetFramework="net452" />
+  <package id="Eyes.Images" version="3.52.0" targetFramework="net452" />
   <package id="log4net" version="2.0.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net452" />
 </packages>

--- a/Eyes/Ranorex.Eyes.Beta.nuspec
+++ b/Eyes/Ranorex.Eyes.Beta.nuspec
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>Ranorex.Eyes</id>
+        <version>2.0.0-beta</version>
+        <title>Ranorex with Applitools Eyes</title>
+        <authors>Ranorex GmbH</authors>
+        <owners>Ranorex GmbH</owners>
+        <projectUrl>https://github.com/ranorex/Packages</projectUrl>
+        <iconUrl>https://www.ranorex.com/rx-studio/rx_logo.png</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Use Applitools Eyes automated visual validation with Ranorex.</description>
+        <copyright>Copyright 2018</copyright>
+        <tags>Ranorex TestAutomation Applitools Eyes</tags>
+        <frameworkAssemblies>
+            <frameworkAssembly assemblyName="System" />
+            <frameworkAssembly assemblyName="System.Drawing" />
+            <frameworkAssembly assemblyName="System.Windows.Forms" />
+        </frameworkAssemblies>
+        <dependencies>
+            <dependency id="PdfiumViewer" version="2.12.0.0"/>
+            <dependency id="PdfiumViewer.Native.x86.v8-xfa" version="2018.4.8.256" />
+            <dependency id="PdfiumViewer.Native.x86_64.v8-xfa" version="2018.4.8.256" />
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="ImageTester\src\csharp\bin\Release\Eyes.Bundle.dll" target="lib" />
+        <file src="ImageTester\src\csharp\lib\Ranorex.Eyes.props" target="build" />
+        <file src="src\Modules\*.cs" target="content\Modules" />
+        <file src="src\UserCodeCollections\*.cs" target="content\UserCodeCollections" />
+        <file src="ImageTester\src\csharp\packages\Eyes.Image.Core.4.16.1\runtimes\win-x64\native\*.*" target="build\runtimes\win-x64\native" />
+    </files>
+</package>

--- a/Eyes/Ranorex.Eyes.nuspec
+++ b/Eyes/Ranorex.Eyes.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Ranorex.Eyes</id>
-        <version>1.1.1</version>
+        <version>2.0.0</version>
         <title>Ranorex with Applitools Eyes</title>
         <authors>Ranorex GmbH</authors>
         <owners>Ranorex GmbH</owners>
@@ -24,7 +24,6 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="ImageTester\src\csharp\bin\Release\Applitools.ImageTester.dll" target="lib" />
         <file src="ImageTester\src\csharp\bin\Release\Eyes.Bundle.dll" target="lib" />
         <file src="src\Modules\*.cs" target="content\Modules" />
         <file src="src\UserCodeCollections\*.cs" target="content\UserCodeCollections" />

--- a/Eyes/src/Modules/EyesWrapper.cs
+++ b/Eyes/src/Modules/EyesWrapper.cs
@@ -3,20 +3,24 @@ using System.Drawing;
 using Ranorex.Core.Testing;
 using Applitools;
 using Applitools.ImageTester;
+using Applitools.Images;
+using Applitools.VisualGrid;
 
 namespace Ranorex.Eyes
 {
     internal static class EyesWrapper
     {
-        internal static readonly log4net.LogManager mgr = null; // explicit ref
+        internal static readonly log4net.LogManager _mgr = null; // explicit ref
 
-        private static readonly Applitools.Images.Eyes eyes = new Applitools.Images.Eyes();
-        private static readonly BatchInfo batch = new BatchInfo();
+        private static readonly ClassicRunner _runner = new ClassicRunner();
+        private static readonly Applitools.Images.Eyes _eyes = new Applitools.Images.Eyes(_runner);
+        private static readonly Configuration _suitConfiguration = new Configuration();
+        private static BatchInfo _batch = new BatchInfo();
 
-        private static string appName;
-        private static string currentTestName = string.Empty;
-        private static string currentBrowserName = string.Empty;
-        private static bool testRunning;
+        private static string _appName;
+        private static string _currentTestName = string.Empty;
+        private static string _currentBrowserName = string.Empty;
+        private static bool _testRunning;
 
         public static int ViewPortHeight { get; set; }
         public static int ViewPortWidth { get; set; }
@@ -30,17 +34,21 @@ namespace Ranorex.Eyes
             int portHeight,
             string matchLevel)
         {
-            eyes.SetAppEnvironment(Host.Local.OSEdition, currentBrowserName);
-            eyes.ApiKey = apiKey;
+            _suitConfiguration
+                .SetApiKey(apiKey)
+                .SetAppName(appName)
+                .SetHideCaret(true)
+                .SetHideScrollbars(true)
+                .SetHostOS(Host.Local.OSEdition);
 
             SetAppName(appName);
+            SetMatchLevel(matchLevel);
 
             if (!string.IsNullOrWhiteSpace(serverURL))
             {
-                eyes.ServerUrl = serverURL;
+                _suitConfiguration.SetServerUrl(serverURL);
             }
 
-            SetMatchLevel(matchLevel);
             if (TestSuite.Current != null)
             {
                 SetBatchName(TestSuite.Current.Name);
@@ -53,6 +61,9 @@ namespace Ranorex.Eyes
 
             ViewPortWidth = portWidth;
             ViewPortHeight = portHeight;
+            _suitConfiguration.SetViewportSize(ViewPortWidth, ViewPortHeight);
+
+            _eyes.SetConfiguration(_suitConfiguration);
         }
 
         public static void CheckImage(Bitmap image, string tag)
@@ -62,7 +73,7 @@ namespace Ranorex.Eyes
                 throw new ArgumentNullException("image");
             }
 
-            eyes.CheckImage(image, tag);
+            _eyes.CheckImage(image, tag);
         }
 
         public static void CheckFolder(string fileOrFolderPath)
@@ -73,7 +84,7 @@ namespace Ranorex.Eyes
                 viewPort = new Size(ViewPortWidth, ViewPortHeight);
             }
 
-            var builder = new SuiteBuilder(fileOrFolderPath, appName, viewPort);
+            var builder = new SuiteBuilder(fileOrFolderPath, _appName, viewPort);
 
             var suite = builder.Build();
             if (suite == null)
@@ -83,7 +94,7 @@ namespace Ranorex.Eyes
             }
 
             Report.Info("Visual Checkpoint - file comparison (PDF/Images).");
-            suite.Run(eyes);
+            suite.Run(_eyes);
         }
 
         [Obsolete("Parameter throwException is no longer used, please use CloseTest() instead.", false)]
@@ -94,39 +105,45 @@ namespace Ranorex.Eyes
 
         public static void CloseTest()
         {
-            if (testRunning)
+            TestResults results;
+            if (_testRunning)
             {
-                var results = eyes.Close(throwEx: false);
+                _eyes.CloseAsync(false);
+                var allTestResults = runner.GetAllTestResults(false);
 
-                if(results.IsNew)
+                foreach (var testResults in allTestResults)
                 {
-                    Report.LogHtml(ReportLevel.Warn, "Visual Testing", string.Format("New baseline created; please approve here: <a href='{0}'>Applitools backend</a>", results.Url));
-                }
-                if(results.IsPassed)
-                {
-                    Report.LogHtml(ReportLevel.Info, "Visual Testing", string.Format("Visual test passed; check results here: <a href='{0}'>Applitools backend</a>", results.Url));
-                }
-                else
-                {
-                    Report.LogHtml(ReportLevel.Failure, "Visual Testing", string.Format("Visual test failed; please check results here: <a href='{0}'>Applitools backend</a>", results.Url));
+                    results = testResults.TestResults;
+                    if (results.IsNew)
+                    {
+                        Report.LogHtml(ReportLevel.Warn, "Visual Testing", string.Format("New baseline created; please approve here: <a href='{0}'>Applitools backend</a>", results.Url));
+                    }
+                    if (results.IsPassed)
+                    {
+                        Report.LogHtml(ReportLevel.Info, "Visual Testing", string.Format("Visual test passed; check results here: <a href='{0}'>Applitools backend</a>", results.Url));
+                    }
+                    else
+                    {
+                        Report.LogHtml(ReportLevel.Failure, "Visual Testing", string.Format("Visual test failed; please check results here: <a href='{0}'>Applitools backend</a>", results.Url));
+                    }
                 }
 
-                testRunning = false;
-                eyes.AbortIfNotClosed();
+                _testRunning = false;
+                _eyes.AbortIfNotClosed();
             }
         }
 
         public static void StartOrContinueTest(string testName)
         {
-            if (!testRunning)
+            if (!_testRunning)
             {
-                eyes.Open(appName, testName, new Size(ViewPortWidth, ViewPortHeight));
-                currentTestName = testName;
-                testRunning = true;
+                _eyes.Open(_appName, testName);
+                _currentTestName = testName;
+                _testRunning = true;
             }
             else
             {
-                if (!testName.Equals(currentTestName))
+                if (!testName.Equals(_currentTestName))
                 {
                     CloseTest();
                     StartOrContinueTest(testName);
@@ -136,7 +153,7 @@ namespace Ranorex.Eyes
 
         public static void SetAppName(string newAppName)
         {
-            appName = newAppName;
+            _appName = newAppName;
         }
 
         public static void SetMatchLevel(string matchLevel)
@@ -147,53 +164,66 @@ namespace Ranorex.Eyes
             {
                 if (matchLevel.ToUpper().Contains("LAYOUT"))
                 {
-                    eyes.DefaultMatchSettings.MatchLevel = MatchLevel.Layout;
+                    _suitConfiguration.MatchLevel = MatchLevel.Layout;
                 }
                 else if (matchLevel.ToUpper().Contains("EXACT"))
                 {
-                    eyes.DefaultMatchSettings.MatchLevel = MatchLevel.Exact;
+                    _suitConfiguration.MatchLevel = MatchLevel.Exact;
                 }
-                else if (matchLevel.ToUpper().Contains("CONTENT"))
+                else if (matchLevel.ToUpper().Contains("IGNORECOLORS"))
                 {
-                    eyes.DefaultMatchSettings.MatchLevel = MatchLevel.Content;
+                    _suitConfiguration.MatchLevel = MatchLevel.IgnoreColors;
                 }
                 else if (matchLevel.ToUpper().Contains("STRICT"))
                 {
-                    eyes.DefaultMatchSettings.MatchLevel = MatchLevel.Strict;
+                    _suitConfiguration.MatchLevel = MatchLevel.Strict;
                 }
                 else
                 {
                     Report.Warn(string.Format("MatchLevel {0} is not valid; fallback to default (strict)", matchLevel));
-                    eyes.DefaultMatchSettings.MatchLevel = MatchLevel.Strict; // Default
+                    _suitConfiguration.MatchLevel = MatchLevel.Strict; // Default
                 }
             }
             else
             {
-                eyes.DefaultMatchSettings.MatchLevel = MatchLevel.Strict; // Default
+                _suitConfiguration.MatchLevel = MatchLevel.Strict; // Default
             }
         }
 
         public static void SetBatchId(string batchId)
         {
-            batch.Id = batchId;
-            eyes.Batch = batch;
+            if (_suitConfiguration.Batch != null) 
+            {
+                _batch = _suitConfiguration.Batch;
+            }
+
+            _batch.Id = batchId;
+            _suitConfiguration.Batch = _batch;
         }
 
         public static void SetBatchName(string batchName)
         {
-            batch.Name = batchName;
-            eyes.Batch = batch;
+            if (_suitConfiguration.Batch != null)
+            {
+                _batch = _suitConfiguration.Batch;
+            }
+
+            _batch.Name = batchName;
+            _suitConfiguration.Batch = _batch;
         }
 
         internal static void SetBrowserName(string browserName)
         {
-            if (currentBrowserName.Equals(browserName))
+            if (_currentBrowserName.Equals(browserName))
             {
                 return;
             }
 
-            currentBrowserName = browserName;
-            eyes.SetAppEnvironment(Host.Local.OSEdition, browserName);
+            _currentBrowserName = browserName;
+            var configuration = _eyes.GetConfiguration();
+            configuration.SetHostApp(browserName);
+            _eyes.SetConfiguration(configuration);
+            _eyes.SetAppEnvironment(Host.Local.OSEdition, browserName);
         }
     }
 }

--- a/Eyes/src/Modules/EyesWrapper.cs
+++ b/Eyes/src/Modules/EyesWrapper.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Drawing;
-using Ranorex.Core.Testing;
 using Applitools;
-using Applitools.ImageTester;
 using Applitools.Images;
-using Applitools.VisualGrid;
+using Ranorex.Core.Testing;
+
 
 namespace Ranorex.Eyes
 {
@@ -84,7 +83,7 @@ namespace Ranorex.Eyes
                 viewPort = new Size(ViewPortWidth, ViewPortHeight);
             }
 
-            var builder = new SuiteBuilder(fileOrFolderPath, _appName, viewPort);
+            var builder = new Applitools.ImageTester.SuiteBuilder(fileOrFolderPath, _appName, viewPort);
 
             var suite = builder.Build();
             if (suite == null)

--- a/Eyes/src/Modules/EyesWrapper.cs
+++ b/Eyes/src/Modules/EyesWrapper.cs
@@ -109,7 +109,7 @@ namespace Ranorex.Eyes
             if (_testRunning)
             {
                 _eyes.CloseAsync(false);
-                var allTestResults = runner.GetAllTestResults(false);
+                var allTestResults = _runner.GetAllTestResults(false);
 
                 foreach (var testResults in allTestResults)
                 {

--- a/Eyes/src/Ranorex.Eyes.csproj
+++ b/Eyes/src/Ranorex.Eyes.csproj
@@ -34,78 +34,97 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Applitools.ImageTester">
-      <HintPath>..\ImageTester\src\csharp\bin\Release\Applitools.ImageTester.dll</HintPath>
-    </Reference>
     <Reference Include="Eyes.Bundle, Version=1.22.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\ImageTester\src\csharp\bin\Release\Eyes.Bundle.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Bootstrapper">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Bootstrapper.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Core">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Core.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Core.Resolver">
       <Private>True</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Core.Resolver.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.Cef">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.Cef.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.ChromeWeb">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.ChromeWeb.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.Delphi">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.Delphi.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.FirefoxWeb">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.FirefoxWeb.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.Flex">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.Flex.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.Java">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.Java.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.Mobile">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.Mobile.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.Msaa">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.Msaa.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.Office">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.Office.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.Qt">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.Qt.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.RawText">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.RawText.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.Sap">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.Sap.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.Test">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.Test.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.Uia">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.Uia.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.Web">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.Web.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.WebDriver">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.WebDriver.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.Win32">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.Win32.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.WinForms">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.WinForms.dll</HintPath>
     </Reference>
     <Reference Include="Ranorex.Plugin.Wpf">
       <Private>False</Private>
+      <HintPath>$(RANOREX_BIN_PATH)\..\$(Configuration)\Ranorex.Plugin.Wpf.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/Eyes/src/Ranorex.Eyes.csproj
+++ b/Eyes/src/Ranorex.Eyes.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Ranorex.Eyes</RootNamespace>
     <AssemblyName>Ranorex.Eyes</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <RanorexVersion>8.2</RanorexVersion>
     <RanorexTargetsPath>$(MSBuildProgramFiles32)\MSBuild\Ranorex$(RanorexVersion)\Ranorex.MSBuild.Targets</RanorexTargetsPath>
@@ -34,7 +34,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Eyes.Bundle, Version=1.22.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Eyes.Bundle, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\ImageTester\src\csharp\bin\Release\Eyes.Bundle.dll</HintPath>
     </Reference>

--- a/Eyes/src/UserCodeCollections/EyesLibrary.cs
+++ b/Eyes/src/UserCodeCollections/EyesLibrary.cs
@@ -111,6 +111,7 @@ namespace Ranorex.Eyes
         		throw new ArgumentNullException("adapter");
         	}
 
+            EyesWrapper.SetBrowserName(GetBrowserName(adapter));
             EyesWrapper.StartOrContinueTest(GetTestCaseName());
             Report.Info(string.Format("Applitools 'CheckImage' called with screenshot from repository item '{0}'.", adapter));
 
@@ -118,7 +119,6 @@ namespace Ranorex.Eyes
             if (adapter.Element.HasCapability("webdocument"))
             {
                 var webDocument = adapter.As<WebDocument>();
-                EyesWrapper.SetBrowserName(webDocument.BrowserName);
                 if (EyesWrapper.ViewPortWidth > 0 && EyesWrapper.ViewPortHeight > 0)
                 {
                     webDocument.Browser.Resize(EyesWrapper.ViewPortWidth, EyesWrapper.ViewPortHeight);
@@ -126,6 +126,36 @@ namespace Ranorex.Eyes
 
                 webDocument.WaitForDocumentLoaded();
                 image = webDocument.CaptureFullPageScreenshot(screenshotCaptureFlag);
+            }
+            else
+            {
+                image = Imaging.CaptureImage(adapter.Element);
+            }
+
+            EyesWrapper.CheckImage(image, stepDescription);
+        }
+
+        private static string GetTestCaseName()
+        {
+            var testCaseName = string.Empty;
+            if (TestSuite.Current != null)
+            {
+                testCaseName = TestSuite.Current.CurrentTestContainer.Name;
+            }
+            return testCaseName;
+        }
+
+        private static string GetBrowserName(Adapter adapter)
+        {
+            if (adapter == null)
+            {
+                throw new ArgumentNullException("adapter");
+            }
+
+            if (adapter.Element.HasCapability("webdocument"))
+            {
+                var webDocument = adapter.As<WebDocument>();
+                return webDocument.BrowserName;
             }
             else
             {
@@ -141,21 +171,8 @@ namespace Ranorex.Eyes
                     browserName = parent.As<WebDocument>().BrowserName;
                 }
 
-                EyesWrapper.SetBrowserName(browserName);
-                image = Imaging.CaptureImage(adapter.Element);
+                return browserName;
             }
-
-            EyesWrapper.CheckImage(image, stepDescription);
-        }
-
-        private static string GetTestCaseName()
-        {
-            var testCaseName = string.Empty;
-            if (TestSuite.Current != null)
-            {
-                testCaseName = TestSuite.Current.CurrentTestContainer.Name;
-            }
-            return testCaseName;
         }
     }
 }


### PR DESCRIPTION
Updated following nuget packages:
-Eyes.Image.Core.DotNet to 4.16.1
-Eyes.Image.DotNet to 3.52.0
-Newtonsoft.Json to 13.0.3
Installed new package:
-ILRepack.Lib.MSBuild.Task 2.0.34
Made new Eyes.Bundle and updated version to 2.0.0
*Ranorex.Eyes project:
-Rewrote code in EyesWrapper
-Added new method for getting browser name in EyesLibrary